### PR TITLE
Add TCP server to mesh-io

### DIFF
--- a/Makefile.mesh
+++ b/Makefile.mesh
@@ -14,6 +14,8 @@ mesh_sources = mesh/mesh.h mesh/mesh.c \
 				mesh/mesh-io.h mesh/mesh-io.c \
 				mesh/mesh-mgmt.c mesh/mesh-mgmt.h \
 				mesh/error.h mesh/mesh-io-api.h \
+				mesh/silvair-io.h \
+				mesh/silvair-io.c \
 				mesh/mesh-io-generic.h \
 				mesh/mesh-io-generic.c \
 				mesh/mesh-io-silvair.h \

--- a/Makefile.mesh
+++ b/Makefile.mesh
@@ -20,6 +20,8 @@ mesh_sources = mesh/mesh.h mesh/mesh.c \
 				mesh/mesh-io-generic.c \
 				mesh/mesh-io-silvair.h \
 				mesh/mesh-io-silvair.c \
+				mesh/mesh-io-tcpserver.h \
+				mesh/mesh-io-tcpserver.c \
 				mesh/net.h mesh/net.c \
 				mesh/crypto.h mesh/crypto.c \
 				mesh/friend.h mesh/friend.c \

--- a/mesh/main.c
+++ b/mesh/main.c
@@ -68,7 +68,9 @@ static void usage(void)
 	       "\t\tUse generic HCI io on interface hci<index>, or the first\n"
 	       "\t\tavailable one\n"
 	       "\tsilvair:<tty>\n"
-	       "\t\tUse Silvair Radio SLIP protocol on <tty>\n");
+	       "\t\tUse Silvair Radio SLIP protocol on <tty>\n"
+	       "\ttcpserver:<port>\n"
+	       "\t\tUse Silvair Radio SLIP protocol over TCP/IP\n");
 }
 
 static void do_debug(const char *str, void *user_data)
@@ -149,6 +151,21 @@ static bool parse_io(const char *optarg, enum mesh_io_type *type, void **opts)
 		*type = MESH_IO_TYPE_SILVAIR;
 
 		optarg += strlen("silvair");
+
+		if (*optarg != ':')
+			return false;
+
+		optarg++;
+
+		*opts = l_strdup(optarg);
+
+		return true;
+	}
+
+	if (strstr(optarg, "tcpserver") == optarg) {
+		*type = MESH_IO_TYPE_TCPSERVER;
+
+		optarg += strlen("tcpserver");
 
 		if (*optarg != ':')
 			return false;

--- a/mesh/mesh-io-silvair.c
+++ b/mesh/mesh-io-silvair.c
@@ -388,9 +388,6 @@ static void send_flush(struct mesh_io_private *pvt)
 		if (!tx || tx->instant > instant)
 			break;
 
-		tx = l_queue_pop_head(pvt->tx_pkts);
-		l_free(tx);
-
 		if (pvt->iface_fd >= 0) {
 			if (!silvair_send_packet(io, tx->data, tx->len,
 								tx->instant,
@@ -406,6 +403,10 @@ static void send_flush(struct mesh_io_private *pvt)
 				return;
 			}
 		}
+
+		tx = l_queue_pop_head(pvt->tx_pkts);
+		l_free(tx);
+
 	} while (tx);
 
 	if (tx)

--- a/mesh/mesh-io-silvair.c
+++ b/mesh/mesh-io-silvair.c
@@ -16,10 +16,6 @@
  *  Lesser General Public License for more details.
  *
  */
-#ifndef __packed
-#define __packed __attribute__((packed))
-#endif
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -45,11 +41,7 @@
 #include "mesh/mesh-io.h"
 #include "mesh/mesh-io-api.h"
 #include "mesh/mesh-io-silvair.h"
-
-#define SLIP_END     0300
-#define SLIP_ESC     0333
-#define SLIP_ESC_END 0334
-#define SLIP_ESC_ESC 0335
+#include "mesh/silvair-io.h"
 
 struct mesh_io_private {
 	char tty_name[PATH_MAX];
@@ -65,13 +57,8 @@ struct mesh_io_private {
 	struct l_queue *tx_pkts;
 	uint8_t filters[3]; /* Simple filtering on AD type only */
 	struct tx_pkt *tx;
-	uint16_t counter;
 
-	struct slip {
-		uint8_t buf[512];
-		size_t offset;
-		bool esc;
-	} slip;
+	struct slip slip;
 };
 
 struct pvt_rx_reg {
@@ -97,89 +84,6 @@ struct tx_pattern {
 	const uint8_t			*data;
 	uint8_t				len;
 };
-
-enum silvair_phy {
-	SILVAIR_PHY_1MBIT	= 0x03,
-	SILVAIR_PHY_2MBIT	= 0x04,
-	SILVAIR_PHY_NONE	= 0xff,
-};
-
-enum silvair_pwr {
-	SILVAIR_PWR_PLUS_8_DBM		= 0x08,
-	SILVAIR_PWR_PLUS_7_DBM		= 0x07,
-	SILVAIR_PWR_PLUS_6_DBM		= 0x06,
-	SILVAIR_PWR_PLUS_5_DBM		= 0x05,
-	SILVAIR_PWR_PLUS_4_DBM		= 0x04,
-	SILVAIR_PWR_PLUS_3_DBM		= 0x03,
-	SILVAIR_PWR_PLUS_2_DBM		= 0x02,
-	SILVAIR_PWR_ZERO_DBM		= 0x00,
-	SILVAIR_PWR_MINUS_4_DB		= 0xFC,
-	SILVAIR_PWR_MINUS_8_DBM		= 0xF8,
-	SILVAIR_PWR_MINUS_12_DBM	= 0xF4,
-	SILVAIR_PWR_MINUS_16_DBM	= 0xF0,
-	SILVAIR_PWR_MINUS_20_DBM	= 0xEC,
-	SILVAIR_PWR_MINUS_30_DBM	= 0xFF,
-	SILVAIR_PWR_MINUS_40_DBM	= 0xD8,
-};
-
-enum silvair_pkt_type {
-	SILVAIR_EVT_RX		= 0x06,
-	SILVAIR_CMD_TX		= 0x18,
-	SILVAIR_CMD_RX		= 0x19,
-	SILVAIR_CMD_BOOTLOADER	= 0x1A,
-	SILVAIR_CMD_FILTER	= 0x1B,
-	SILVAIR_EVT_RESET	= 0x1C,
-};
-
-struct silvair_pkt_hdr {
-	uint8_t				hdr_len;
-	uint8_t				pld_len;
-	uint8_t				version;
-	uint16_t			counter;
-	enum silvair_pkt_type		type :8;
-} __packed;
-
-struct silvair_rx_evt_hdr {
-	uint8_t		hdr_len;
-	uint8_t		crc;
-	uint8_t		channel;
-	uint8_t		rssi;
-	uint16_t	counter;
-	uint32_t	timestamp;
-} __packed;
-
-struct silvair_adv_hdr {
-	uint8_t		type	: 4;
-	uint8_t		__rfu1	: 2;
-	uint8_t		tx_add	: 1;
-	uint8_t		rx_add	: 1;
-	uint8_t		size	: 6;
-	uint8_t		__rfu2	: 2;
-} __packed;
-
-struct silvair_rx_evt_pld {
-	uint32_t		access_address;
-	struct silvair_adv_hdr	header;
-	uint8_t			__unused;
-	uint8_t			address[6];
-	uint8_t			adv_data[0];
-} __packed;
-
-struct silvair_tx_cmd_hdr {
-	uint8_t			hdr_len;
-	uint8_t			channels[8];
-	enum silvair_phy	phy : 8;
-	enum silvair_pwr	pwr : 8;
-	uint16_t		counter;
-} __packed;
-
-struct silvair_tx_cmd_pld {
-	uint32_t		access_address;
-	struct silvair_adv_hdr	header;
-	uint8_t			__unused;
-	uint8_t			address[6];
-	uint8_t			adv_data[0];
-} __packed;
 
 static uint32_t get_instant(void)
 {
@@ -221,115 +125,6 @@ static void process_rx(struct mesh_io_private *pvt, int8_t rssi,
 	l_queue_foreach(pvt->rx_regs, process_rx_callbacks, &rx);
 }
 
-static void process_evt_rx(struct mesh_io *io, uint32_t instant,
-		const struct silvair_pkt_hdr *pkt_hdr, size_t len)
-{
-	const struct silvair_rx_evt_hdr *rx_hdr;
-	const struct silvair_rx_evt_pld *rx_pld;
-	const uint8_t *adv;
-	int8_t rssi;
-
-	if (len < sizeof(*rx_hdr))
-		return;
-
-	rx_hdr = (struct silvair_rx_evt_hdr *)(pkt_hdr + 1);
-	len -= sizeof(*rx_hdr);
-
-	if (len < sizeof(*rx_pld))
-		return;
-
-	rssi = rx_hdr->rssi;
-
-	rx_pld = (struct silvair_rx_evt_pld *)(rx_hdr + 1);
-
-	adv = rx_pld->adv_data;
-
-	while (adv < (const uint8_t *)rx_pld + pkt_hdr->pld_len) {
-		uint8_t field_len = adv[0];
-
-		/* Check for the end of advertising data */
-		if (field_len == 0)
-			break;
-
-		/* Do not continue data parsing if got incorrect length */
-		if (adv + field_len + 1 >
-			(const uint8_t *)rx_pld + pkt_hdr->pld_len)
-			break;
-
-		process_rx(io->pvt, rssi, instant, adv + 1, field_len);
-
-		adv += field_len + 1;
-	}
-}
-
-static void process_packet(struct mesh_io *io, uint8_t *buf, size_t size,
-							uint32_t instant)
-{
-	const struct silvair_pkt_hdr *pkt_hdr;
-	size_t len = size;
-
-	if (len < sizeof(*pkt_hdr))
-		return;
-
-	pkt_hdr = (struct silvair_pkt_hdr *)buf;
-	len -= sizeof(*pkt_hdr);
-
-	switch (pkt_hdr->type) {
-	case SILVAIR_EVT_RX:
-		process_evt_rx(io, instant, pkt_hdr, len);
-		break;
-	case SILVAIR_EVT_RESET:
-	case SILVAIR_CMD_TX:
-	case SILVAIR_CMD_RX:
-	case SILVAIR_CMD_BOOTLOADER:
-	case SILVAIR_CMD_FILTER:
-		break;
-	}
-}
-
-static void process_slip(struct mesh_io *io, uint8_t *buf, size_t size,
-							uint32_t instant)
-{
-	struct slip *slip = &io->pvt->slip;
-
-	for (uint8_t *i = buf; i != buf + size; ++i) {
-		switch (*i) {
-		case SLIP_END:
-			if (slip->offset)
-				process_packet(io, slip->buf, slip->offset,
-								instant);
-
-			slip->offset = 0;
-			break;
-
-		case SLIP_ESC:
-			slip->esc = true;
-			break;
-
-		default:
-			if (!slip->esc) {
-				slip->buf[slip->offset++] = *i;
-				break;
-			}
-
-			switch (*i) {
-			case SLIP_ESC_ESC:
-				slip->buf[slip->offset++] = SLIP_ESC;
-				break;
-
-			case SLIP_ESC_END:
-				slip->buf[slip->offset++] = SLIP_END;
-				break;
-
-			default:
-				slip->offset = 0;
-			}
-
-			slip->esc = false;
-		}
-	}
-}
-
 static bool io_read_callback(struct io *io, void *user_data)
 {
 	struct mesh_io *mesh_io = user_data;
@@ -351,9 +146,10 @@ static bool io_read_callback(struct io *io, void *user_data)
 	instant = get_instant();
 
 	if (mesh_io->pvt->iface_fd >= 0)
-		process_packet(mesh_io, buf, r, instant);
+		silvair_process_packet(mesh_io, buf, r, instant, process_rx);
 	else
-		process_slip(mesh_io, buf, r, instant);
+		silvair_process_slip(mesh_io, &mesh_io->pvt->slip,
+						buf, r, instant, process_rx);
 
 	return true;
 }
@@ -571,64 +367,20 @@ static bool silvair_io_caps(struct mesh_io *io, struct mesh_io_caps *caps)
 	return true;
 }
 
-static bool send_packet(struct mesh_io *io, uint8_t *buf, ssize_t size)
+static bool io_write(struct mesh_io_private *pvt, uint32_t instant,
+					const uint8_t *buf, size_t size)
 {
-	int fd = io_get_fd(io->pvt->io);
+	int fd = io_get_fd(pvt->io);
 
-	return write(fd, buf, size) == size;
-}
-
-static bool send_slip(struct mesh_io *io, uint8_t *buf, ssize_t size)
-{
-	static const uint8_t end = SLIP_END;
-	static const uint8_t esc_end[2] = { SLIP_ESC, SLIP_ESC_END };
-	static const uint8_t esc_esc[2] = { SLIP_ESC, SLIP_ESC_ESC };
-
-	int fd = io_get_fd(io->pvt->io);
-
-	if (write(fd, &end, 1) != 1)
-		return false;
-
-	for (uint8_t *i = buf; i != buf + size; ++i) {
-		switch (*i) {
-		case SLIP_END:
-			if (write(fd, esc_end, 2) != 2)
-				return false;
-			break;
-
-		case SLIP_ESC:
-			if (write(fd, esc_esc, 2) != 2)
-				return false;
-			break;
-
-		default:
-			if (write(fd, i, 1) != 1)
-				return false;
-		}
-	}
-
-	if (write(fd, &end, 1) != 1)
-		return false;
-
-	return true;
+	int w = write(fd, buf, size);
+	return (w > 0 && (size_t)w == size);
 }
 
 static void send_flush(struct mesh_io_private *pvt)
 {
-	uint8_t buf[512] = { 0 };
-	struct silvair_pkt_hdr *pkt_hdr;
-	struct silvair_tx_cmd_hdr *tx_hdr;
-	struct silvair_tx_cmd_pld *tx_pld;
-	uint8_t *adv_data;
-	int len;
 	struct tx_pkt *tx;
 	uint32_t instant = get_instant();
 	struct mesh_io *io = l_container_of(&pvt, struct mesh_io, pvt);
-
-	pkt_hdr = (struct silvair_pkt_hdr *)buf;
-	tx_hdr = (struct silvair_tx_cmd_hdr *)(pkt_hdr + 1);
-	tx_pld = (struct silvair_tx_cmd_pld *)(tx_hdr + 1);
-	adv_data = tx_pld->adv_data;
 
 	do {
 		tx = l_queue_peek_head(pvt->tx_pkts);
@@ -636,50 +388,24 @@ static void send_flush(struct mesh_io_private *pvt)
 		if (!tx || tx->instant > instant)
 			break;
 
-		pkt_hdr->hdr_len = sizeof(*pkt_hdr);
-		pkt_hdr->pld_len = sizeof(*tx_hdr) + sizeof(*tx_pld) +
-								tx->len + 1;
-		pkt_hdr->version = 1;
-		pkt_hdr->counter = L_CPU_TO_BE16(pvt->counter);
-		pkt_hdr->type = SILVAIR_CMD_TX;
-
-		tx_hdr->hdr_len = sizeof(*tx_hdr);
-		tx_hdr->channels[3] = 0xe0;
-		tx_hdr->phy = SILVAIR_PHY_1MBIT;
-		tx_hdr->pwr = SILVAIR_PWR_MINUS_8_DBM;
-
-		tx_pld->access_address = L_CPU_TO_BE32(0x8e89bed6);
-		/* ADV_NOCONN_IND */
-		tx_pld->header.type = 2;
-
-		/* bdaddress + type tag + data */
-		tx_pld->header.size = 6 + tx->len + 1;
-		tx_hdr->counter = L_CPU_TO_BE16(pvt->counter + 1);
-
-		l_getrandom(tx_pld->address, sizeof(tx_pld->address));
-		tx_pld->address[5] |= 0xc0;
-
-		adv_data[0] = tx->len;
-		memcpy(adv_data + 1, tx->data, tx->len);
-
 		tx = l_queue_pop_head(pvt->tx_pkts);
 		l_free(tx);
 
-		len = pkt_hdr->hdr_len + pkt_hdr->pld_len;
-
 		if (pvt->iface_fd >= 0) {
-			if (!send_packet(io, buf, len)) {
+			if (!silvair_send_packet(io, tx->data, tx->len,
+								tx->instant,
+								io_write)) {
 				l_error("write failed: %s", strerror(errno));
 				return;
 			}
 		} else {
-			if (!send_slip(io, buf, len)) {
+			if (!silvair_send_slip(io, tx->data, tx->len,
+								tx->instant,
+								io_write)) {
 				l_error("write failed: %s", strerror(errno));
 				return;
 			}
 		}
-
-		pvt->counter += 2;
 	} while (tx);
 
 	if (tx)
@@ -709,7 +435,7 @@ static int compare_tx_pkt_instant(const void *a, const void *b,
 }
 
 static void send_pkt(struct mesh_io_private *pvt,
-		     const uint8_t *data, uint16_t len, uint32_t instant)
+			const uint8_t *data, uint16_t len, uint32_t instant)
 {
 	struct tx_pkt *tx = l_new(struct tx_pkt, 1);
 

--- a/mesh/mesh-io-tcpserver.c
+++ b/mesh/mesh-io-tcpserver.c
@@ -1,0 +1,552 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <termios.h>
+#include <arpa/inet.h>
+#include <linux/tty.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/limits.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <ell/ell.h>
+
+#include <stdio.h>
+
+#include "src/shared/io.h"
+
+#include "mesh/mesh-io.h"
+#include "mesh/mesh-io-api.h"
+#include "mesh/mesh-io-tcpserver.h"
+#include "mesh/silvair-io.h"
+
+struct mesh_io_private {
+	int server_fd;
+	struct sockaddr_in server_addr;
+	struct io *server_io;
+
+	int client_fd;
+	struct sockaddr_in client_addr;
+	struct io *client_io;
+
+	struct l_timeout *tx_timeout;
+	struct l_queue *rx_regs;
+	struct l_queue *tx_pkts;
+	uint8_t filters[3]; /* Simple filtering on AD type only */
+	struct tx_pkt *tx;
+
+	struct slip slip;
+};
+
+struct pvt_rx_reg {
+	uint8_t filter_id;
+	mesh_io_recv_func_t cb;
+	void *user_data;
+};
+
+struct process_data {
+	struct mesh_io_private		*pvt;
+	const uint8_t			*data;
+	uint8_t				len;
+	struct mesh_io_recv_info	info;
+};
+
+struct tx_pkt {
+	uint32_t	instant;
+	uint8_t		len;
+	uint8_t		data[30];
+};
+
+struct tx_pattern {
+	const uint8_t			*data;
+	uint8_t				len;
+};
+
+static uint32_t get_instant(void)
+{
+	struct timeval tm;
+	uint32_t instant;
+
+	gettimeofday(&tm, NULL);
+	instant = tm.tv_sec * 1000;
+	instant += tm.tv_usec / 1000;
+
+	return instant;
+}
+
+static void process_rx_callbacks(void *v_rx, void *v_reg)
+{
+	struct pvt_rx_reg *rx_reg = v_rx;
+	struct process_data *rx = v_reg;
+	uint8_t ad_type;
+
+	ad_type = rx->pvt->filters[rx_reg->filter_id - 1];
+
+	if (rx->data[0] == ad_type && rx_reg->cb)
+		rx_reg->cb(rx_reg->user_data, &rx->info, rx->data, rx->len);
+}
+
+static void process_rx(struct mesh_io_private *pvt, int8_t rssi,
+					uint32_t instant,
+					const uint8_t *data, uint8_t len)
+{
+	struct process_data rx = {
+		.pvt = pvt,
+		.data = data,
+		.len = len,
+		.info.instant = instant,
+		.info.chan = 7,
+		.info.rssi = rssi,
+	};
+
+	l_queue_foreach(pvt->rx_regs, process_rx_callbacks, &rx);
+}
+
+static bool io_read_callback(struct io *io, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+	uint8_t buf[512];
+	uint32_t instant;
+	int r;
+	int fd;
+
+	fd = io_get_fd(mesh_io->pvt->client_io);
+	if (fd < 0)
+		return false;
+
+	r = read(fd, buf, sizeof(buf));
+
+	if (r <= 0)
+	{
+		l_info("Disconnected %s:%hu",
+				inet_ntoa(mesh_io->pvt->client_addr.sin_addr),
+				ntohs(mesh_io->pvt->client_addr.sin_port));
+
+		close(fd);
+		mesh_io->pvt->client_fd = -1;
+		return false;
+	}
+
+	instant = get_instant();
+
+	if (mesh_io->pvt->client_fd >= 0)
+		silvair_process_slip(mesh_io, &mesh_io->pvt->slip,
+						buf, r, instant, process_rx);
+
+	return true;
+}
+
+static bool io_accept_callback(struct io *io, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+	int server_fd;
+	int client_fd;
+	struct sockaddr_in client_addr;
+	socklen_t client_addrlen = sizeof(client_addr);
+
+	server_fd = io_get_fd(mesh_io->pvt->server_io);
+	if (server_fd < 0)
+		return false;
+
+	client_fd = accept(server_fd, (struct sockaddr *)&client_addr,
+							&client_addrlen);
+
+	if (mesh_io->pvt->client_fd >= 0) {
+		l_info("Dropped %s:%hu",
+				inet_ntoa(client_addr.sin_addr),
+				ntohs(client_addr.sin_port));
+
+		close(client_fd);
+		return true;
+	}
+
+	if (client_fd < 0)
+		return false;
+
+	mesh_io->pvt->client_fd = client_fd;
+	memcpy(&mesh_io->pvt->client_addr, &client_addr, sizeof(client_addr));
+
+	mesh_io->pvt->client_io = io_new(mesh_io->pvt->client_fd);
+	io_set_read_handler(mesh_io->pvt->client_io, io_read_callback, mesh_io,
+									NULL);
+
+	l_info("Connected %s:%hu",
+				inet_ntoa(mesh_io->pvt->client_addr.sin_addr),
+				ntohs(mesh_io->pvt->client_addr.sin_port));
+
+	return true;
+}
+
+static void send_timeout(struct l_timeout *timeout, void *user_data);
+
+static bool tcpserver_io_init(struct mesh_io *io, void *opts)
+{
+	uint16_t port = 0;
+
+	char *opt = opts;
+	char *delim;
+
+	do {
+		delim = strchr(opt, ':');
+
+		if (delim)
+			*delim = '\0';
+
+		if (sscanf(opt, "%hu", &port) != 1)
+			return false;
+
+		opt = delim + 1;
+
+	} while (delim);
+
+	if (!io || io->pvt)
+		return false;
+
+	if (!port)
+		return false;
+
+	io->pvt = l_new(struct mesh_io_private, 1);
+	io->pvt->client_fd = -1;
+
+	io->pvt->server_fd = socket(AF_INET, SOCK_STREAM, 0);
+	setsockopt(io->pvt->server_fd, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 },
+								sizeof(int));
+	io->pvt->server_addr.sin_addr.s_addr = INADDR_ANY;
+	io->pvt->server_addr.sin_port = htons(port);
+	if (bind(io->pvt->server_fd, (struct sockaddr *)&io->pvt->server_addr,
+					sizeof(io->pvt->server_addr)) < 0) {
+		l_error("Failed to start mesh io (bind): %s",
+							strerror(errno));
+		return false;
+	}
+
+	if (listen(io->pvt->server_fd, 1) < 0) {
+		l_error("Failed to start mesh io (listen): %s",
+							strerror(errno));
+		return false;
+	}
+
+	io->pvt->server_io = io_new(io->pvt->server_fd);
+
+	io->pvt->rx_regs = l_queue_new();
+	io->pvt->tx_pkts = l_queue_new();
+
+	if (!io_set_read_handler(io->pvt->server_io, io_accept_callback, io,
+									NULL))
+		return false;
+
+	io->pvt->tx_timeout = l_timeout_create_ms(0, send_timeout, io->pvt,
+									NULL);
+
+	l_info("Started mesh on tcp port %d", port);
+
+	return true;
+}
+
+static bool tcpserver_io_destroy(struct mesh_io *io)
+{
+	struct mesh_io_private *pvt = io->pvt;
+
+	if (!pvt)
+		return true;
+
+	close(io->pvt->server_fd);
+	io_destroy(io->pvt->server_io);
+
+	close(io->pvt->client_fd);
+	io_destroy(io->pvt->client_io);
+
+	l_timeout_remove(pvt->tx_timeout);
+	l_queue_destroy(pvt->rx_regs, l_free);
+	l_queue_destroy(pvt->tx_pkts, l_free);
+	l_free(pvt);
+	io->pvt = NULL;
+
+	return true;
+}
+
+static bool tcpserver_io_caps(struct mesh_io *io, struct mesh_io_caps *caps)
+{
+	struct mesh_io_private *pvt = io->pvt;
+
+	if (!pvt || !caps)
+		return false;
+
+	caps->max_num_filters = sizeof(pvt->filters);
+	caps->window_accuracy = 50;
+
+	return true;
+}
+
+static bool client_write(struct mesh_io_private *pvt, uint32_t instant,
+					const uint8_t *buf, size_t size)
+{
+	int fd = io_get_fd(pvt->client_io);
+
+	int w = write(fd, buf, size);
+	return (w > 0 && (size_t)w == size);
+}
+
+static void send_flush(struct mesh_io_private *pvt)
+{
+	struct tx_pkt *tx;
+	uint32_t instant = get_instant();
+	struct mesh_io *io = l_container_of(&pvt, struct mesh_io, pvt);
+
+	do {
+		tx = l_queue_peek_head(pvt->tx_pkts);
+
+		if (!tx || tx->instant > instant)
+			break;
+
+		tx = l_queue_pop_head(pvt->tx_pkts);
+		l_free(tx);
+
+		if (!silvair_send_slip(io, tx->data, tx->len, tx->instant,
+								client_write)) {
+			l_error("write failed: %s", strerror(errno));
+			return;
+		}
+	} while (tx);
+
+	if (tx)
+		l_timeout_modify_ms(pvt->tx_timeout, tx->instant - instant);
+}
+
+static void send_timeout(struct l_timeout *timeout, void *user_data)
+{
+	struct mesh_io_private *pvt = user_data;
+
+	if (!pvt)
+		return;
+
+	send_flush(pvt);
+}
+
+static int compare_tx_pkt_instant(const void *a, const void *b,
+							void *user_data)
+{
+	const struct tx_pkt *lhs = a;
+	const struct tx_pkt *rhs = b;
+
+	if (lhs->instant == rhs->instant)
+		return 0;
+
+	return lhs->instant < rhs->instant ? -1 : 1;
+}
+
+static void send_pkt(struct mesh_io_private *pvt,
+			const uint8_t *data, uint16_t len, uint32_t instant)
+{
+	struct tx_pkt *tx = l_new(struct tx_pkt, 1);
+
+	tx->instant = instant;
+	tx->len = len;
+	memcpy(tx->data, data, len);
+
+	l_queue_insert(pvt->tx_pkts, tx, compare_tx_pkt_instant, NULL);
+
+	send_flush(pvt);
+}
+
+static bool tcpserver_io_send(struct mesh_io *io,
+					struct mesh_io_send_info *info,
+					const uint8_t *data, uint16_t len)
+{
+	struct mesh_io_private *pvt = io->pvt;
+	uint32_t instant;
+	uint16_t interval;
+	uint8_t delay;
+	int i;
+
+	if (!info || !data || !len)
+		return false;
+
+	switch (info->type) {
+	case MESH_IO_TIMING_TYPE_GENERAL:
+		instant = get_instant();
+		interval = info->u.gen.interval;
+
+		if (info->u.gen.min_delay == info->u.gen.max_delay)
+			delay = info->u.gen.min_delay;
+		else {
+			l_getrandom(&delay, sizeof(delay));
+			delay %= info->u.gen.max_delay - info->u.gen.min_delay;
+			delay += info->u.gen.min_delay;
+		}
+
+		for (i = 0; i < info->u.gen.cnt; ++i)
+			send_pkt(pvt, data, len,
+					instant + delay + interval * i);
+		break;
+	case MESH_IO_TIMING_TYPE_POLL:
+		instant = get_instant();
+
+		if (info->u.gen.min_delay == info->u.gen.max_delay)
+			delay = info->u.gen.min_delay;
+		else {
+			l_getrandom(&delay, sizeof(delay));
+			delay %= info->u.gen.max_delay - info->u.gen.min_delay;
+			delay += info->u.gen.min_delay;
+		}
+
+		send_pkt(pvt, data, len, instant + delay);
+		break;
+
+	case MESH_IO_TIMING_TYPE_POLL_RSP:
+		instant = info->u.poll_rsp.instant;
+		delay = info->u.poll_rsp.delay;
+
+		send_pkt(pvt, data, len, instant + delay);
+		break;
+	}
+
+	return true;
+}
+
+
+
+static bool find_by_filter_id(const void *a, const void *b)
+{
+	const struct pvt_rx_reg *rx_reg = a;
+	uint8_t filter_id = L_PTR_TO_UINT(b);
+
+	return rx_reg->filter_id == filter_id;
+}
+
+static bool tcpserver_io_reg(struct mesh_io *io, uint8_t filter_id,
+				mesh_io_recv_func_t cb, void *user_data)
+{
+	struct mesh_io_private *pvt = io->pvt;
+	struct pvt_rx_reg *rx_reg;
+
+	l_info("%s %d", __func__, filter_id);
+	if (!cb || !filter_id || filter_id > sizeof(pvt->filters))
+		return false;
+
+	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter_id,
+						L_UINT_TO_PTR(filter_id));
+
+	if (!rx_reg) {
+		rx_reg = l_new(struct pvt_rx_reg, 1);
+		if (!rx_reg)
+			return false;
+	}
+
+	rx_reg->filter_id = filter_id;
+	rx_reg->cb = cb;
+	rx_reg->user_data = user_data;
+
+	l_queue_push_head(pvt->rx_regs, rx_reg);
+
+	return true;
+}
+
+static bool tcpserver_io_dereg(struct mesh_io *io, uint8_t filter_id)
+{
+	struct mesh_io_private *pvt = io->pvt;
+
+	struct pvt_rx_reg *rx_reg;
+
+	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter_id,
+						L_UINT_TO_PTR(filter_id));
+
+	if (rx_reg)
+		l_free(rx_reg);
+
+	return true;
+}
+
+static bool tcpserver_io_set(struct mesh_io *io,
+		uint8_t filter_id, const uint8_t *data, uint8_t len,
+		mesh_io_status_func_t callback, void *user_data)
+{
+	struct mesh_io_private *pvt = io->pvt;
+
+	l_info("%s id: %d, --> %2.2x", __func__, filter_id, data[0]);
+	if (!data || !len || !filter_id || filter_id > sizeof(pvt->filters))
+		return false;
+
+	pvt->filters[filter_id - 1] = data[0];
+
+	/* TODO: Delayed Call to successful status */
+
+	return true;
+}
+
+static bool find_by_pattern(const void *a, const void *b)
+{
+	const struct tx_pkt *tx = a;
+	const struct tx_pattern *pattern = b;
+
+	if (tx->len < pattern->len)
+		return false;
+
+	return (!memcmp(tx->data, pattern->data, pattern->len));
+}
+
+static bool tcpserver_io_cancel(struct mesh_io *io, const uint8_t *data,
+								uint8_t len)
+{
+	struct mesh_io_private *pvt = io->pvt;
+	struct tx_pkt *tx;
+	const struct tx_pattern pattern = {
+		.data = data,
+		.len = len
+	};
+
+	if (!data)
+		return false;
+
+	do {
+		tx = l_queue_remove_if(pvt->tx_pkts, find_by_pattern,
+							&pattern);
+		l_free(tx);
+	} while (tx);
+
+	tx = l_queue_peek_head(pvt->tx_pkts);
+
+	if (tx)
+		l_timeout_modify_ms(pvt->tx_timeout,
+						tx->instant - get_instant());
+
+	return true;
+}
+
+const struct mesh_io_api mesh_io_tcpserver = {
+	.init = tcpserver_io_init,
+	.destroy = tcpserver_io_destroy,
+	.caps = tcpserver_io_caps,
+	.send = tcpserver_io_send,
+	.reg = tcpserver_io_reg,
+	.dereg = tcpserver_io_dereg,
+	.set = tcpserver_io_set,
+	.cancel = tcpserver_io_cancel,
+};

--- a/mesh/mesh-io-tcpserver.c
+++ b/mesh/mesh-io-tcpserver.c
@@ -185,6 +185,8 @@ static bool io_accept_callback(struct io *io, void *user_data)
 	if (client_fd < 0)
 		return false;
 
+	fcntl(client_fd, F_SETFL, fcntl(client_fd, F_GETFL, 0) | O_NONBLOCK);
+
 	memcpy(&mesh_io->pvt->client_addr, &client_addr, sizeof(client_addr));
 
 	mesh_io->pvt->client_io = io_new(client_fd);
@@ -231,6 +233,7 @@ static bool tcpserver_io_init(struct mesh_io *io, void *opts)
 	io->pvt = l_new(struct mesh_io_private, 1);
 
 	server_fd = socket(AF_INET, SOCK_STREAM, 0);
+	fcntl(server_fd, F_SETFL, fcntl(server_fd, F_GETFL, 0) | O_NONBLOCK);
 	setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &(int){ 1 },
 								sizeof(int));
 	io->pvt->server_addr.sin_addr.s_addr = INADDR_ANY;

--- a/mesh/mesh-io-tcpserver.c
+++ b/mesh/mesh-io-tcpserver.c
@@ -326,14 +326,14 @@ static void send_flush(struct mesh_io_private *pvt)
 		if (!tx || tx->instant > instant)
 			break;
 
-		tx = l_queue_pop_head(pvt->tx_pkts);
-		l_free(tx);
-
 		if (!silvair_send_slip(io, tx->data, tx->len, tx->instant,
 								client_write)) {
 			l_error("write failed: %s", strerror(errno));
 			return;
 		}
+
+		tx = l_queue_pop_head(pvt->tx_pkts);
+		l_free(tx);
 	} while (tx);
 
 	if (tx)

--- a/mesh/mesh-io-tcpserver.h
+++ b/mesh/mesh-io-tcpserver.h
@@ -1,0 +1,20 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+
+extern const struct mesh_io_api mesh_io_tcpserver;

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -35,8 +35,8 @@
 
 /* List of Supported Mesh-IO Types */
 static const struct mesh_io_table table[] = {
-	{MESH_IO_TYPE_GENERIC,	&mesh_io_generic},
-	{MESH_IO_TYPE_SILVAIR,	&mesh_io_silvair}
+	{MESH_IO_TYPE_GENERIC,		&mesh_io_generic},
+	{MESH_IO_TYPE_SILVAIR,		&mesh_io_silvair}
 };
 
 static struct l_queue *io_list;

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -32,11 +32,13 @@
 /* List of Mesh-IO Type headers */
 #include "mesh/mesh-io-generic.h"
 #include "mesh/mesh-io-silvair.h"
+#include "mesh/mesh-io-tcpserver.h"
 
 /* List of Supported Mesh-IO Types */
 static const struct mesh_io_table table[] = {
 	{MESH_IO_TYPE_GENERIC,		&mesh_io_generic},
-	{MESH_IO_TYPE_SILVAIR,		&mesh_io_silvair}
+	{MESH_IO_TYPE_SILVAIR,		&mesh_io_silvair},
+	{MESH_IO_TYPE_TCPSERVER,	&mesh_io_tcpserver}
 };
 
 static struct l_queue *io_list;

--- a/mesh/mesh-io.h
+++ b/mesh/mesh-io.h
@@ -29,7 +29,8 @@ struct mesh_io;
 enum mesh_io_type {
 	MESH_IO_TYPE_NONE = 0,
 	MESH_IO_TYPE_GENERIC,
-	MESH_IO_TYPE_SILVAIR
+	MESH_IO_TYPE_SILVAIR,
+	MESH_IO_TYPE_TCPSERVER
 };
 
 enum mesh_io_timing_type {

--- a/mesh/silvair-io.c
+++ b/mesh/silvair-io.c
@@ -21,6 +21,20 @@
 #define SLIP_ESC_END 0334
 #define SLIP_ESC_ESC 0335
 
+static const uint32_t silvair_access_address = 0x8e89bed6;
+
+static const uint8_t silvair_channels[8] = {
+	0x00, 0x00, 0x00, 0x0e,
+	0x00, 0x00, 0x00, 0x00,
+};
+
+enum silvair_adv_type
+{
+    SILVAIR_ADV_TYPE_ADV_IND         = 0x00,
+    SILVAIR_ADV_TYPE_ADV_DIRECT_IND  = 0x01,
+    SILVAIR_ADV_TYPE_ADV_NONCONN_IND = 0x02,
+};
+
 enum silvair_phy {
 	SILVAIR_PHY_1MBIT	= 0x03,
 	SILVAIR_PHY_2MBIT	= 0x04,
@@ -291,13 +305,12 @@ static bool send_packet(struct mesh_io *io, uint8_t *buf, size_t size,
 	pkt_hdr->type = SILVAIR_CMD_TX;
 
 	tx_hdr->hdr_len = sizeof(*tx_hdr);
-	tx_hdr->channels[3] = 0xe0;
+	memcpy(tx_hdr->channels, silvair_channels, sizeof(tx_hdr->channels));
 	tx_hdr->phy = SILVAIR_PHY_1MBIT;
 	tx_hdr->pwr = SILVAIR_PWR_MINUS_8_DBM;
 
-	tx_pld->access_address = L_CPU_TO_BE32(0x8e89bed6);
-	/* ADV_NOCONN_IND */
-	tx_pld->header.type = 2;
+	tx_pld->access_address = silvair_access_address;
+	tx_pld->header.type = SILVAIR_ADV_TYPE_ADV_NONCONN_IND;
 
 	/* bdaddress + type tag + data */
 	tx_pld->header.size = 6 + size + 1;

--- a/mesh/silvair-io.c
+++ b/mesh/silvair-io.c
@@ -1,0 +1,321 @@
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "ell/util.h"
+#include "ell/random.h"
+
+#include "mesh/mesh-io.h"
+#include "mesh/mesh-io-api.h"
+#include "mesh/silvair-io.h"
+
+#define SLIP_END     0300
+#define SLIP_ESC     0333
+#define SLIP_ESC_END 0334
+#define SLIP_ESC_ESC 0335
+
+enum silvair_phy {
+	SILVAIR_PHY_1MBIT	= 0x03,
+	SILVAIR_PHY_2MBIT	= 0x04,
+	SILVAIR_PHY_NONE	= 0xff,
+};
+
+enum silvair_pwr {
+	SILVAIR_PWR_PLUS_8_DBM		= 0x08,
+	SILVAIR_PWR_PLUS_7_DBM		= 0x07,
+	SILVAIR_PWR_PLUS_6_DBM		= 0x06,
+	SILVAIR_PWR_PLUS_5_DBM		= 0x05,
+	SILVAIR_PWR_PLUS_4_DBM		= 0x04,
+	SILVAIR_PWR_PLUS_3_DBM		= 0x03,
+	SILVAIR_PWR_PLUS_2_DBM		= 0x02,
+	SILVAIR_PWR_ZERO_DBM		= 0x00,
+	SILVAIR_PWR_MINUS_4_DB		= 0xFC,
+	SILVAIR_PWR_MINUS_8_DBM		= 0xF8,
+	SILVAIR_PWR_MINUS_12_DBM	= 0xF4,
+	SILVAIR_PWR_MINUS_16_DBM	= 0xF0,
+	SILVAIR_PWR_MINUS_20_DBM	= 0xEC,
+	SILVAIR_PWR_MINUS_30_DBM	= 0xFF,
+	SILVAIR_PWR_MINUS_40_DBM	= 0xD8,
+};
+
+enum silvair_pkt_type {
+	SILVAIR_EVT_RX		= 0x06,
+	SILVAIR_CMD_TX		= 0x18,
+	SILVAIR_CMD_RX		= 0x19,
+	SILVAIR_CMD_BOOTLOADER	= 0x1A,
+	SILVAIR_CMD_FILTER	= 0x1B,
+	SILVAIR_EVT_RESET	= 0x1C,
+};
+
+struct silvair_pkt_hdr {
+	uint8_t				hdr_len;
+	uint8_t				pld_len;
+	uint8_t				version;
+	uint16_t			counter;
+	enum silvair_pkt_type		type :8;
+} __packed;
+
+struct silvair_rx_evt_hdr {
+	uint8_t		hdr_len;
+	uint8_t		crc;
+	uint8_t		channel;
+	uint8_t		rssi;
+	uint16_t	counter;
+	uint32_t	timestamp;
+} __packed;
+
+struct silvair_adv_hdr {
+	uint8_t		type	: 4;
+	uint8_t		__rfu1	: 2;
+	uint8_t		tx_add	: 1;
+	uint8_t		rx_add	: 1;
+	uint8_t		size	: 6;
+	uint8_t		__rfu2	: 2;
+} __packed;
+
+struct silvair_rx_evt_pld {
+	uint32_t		access_address;
+	struct silvair_adv_hdr	header;
+	uint8_t			__unused;
+	uint8_t			address[6];
+	uint8_t			adv_data[0];
+} __packed;
+
+struct silvair_tx_cmd_hdr {
+	uint8_t			hdr_len;
+	uint8_t			channels[8];
+	enum silvair_phy	phy : 8;
+	enum silvair_pwr	pwr : 8;
+	uint16_t		counter;
+} __packed;
+
+struct silvair_tx_cmd_pld {
+	uint32_t		access_address;
+	struct silvair_adv_hdr	header;
+	uint8_t			__unused;
+	uint8_t			address[6];
+	uint8_t			adv_data[0];
+} __packed;
+
+
+typedef bool (*write_cb)(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb);
+
+static void process_evt_rx(struct mesh_io *io,
+					uint32_t instant,
+					const struct silvair_pkt_hdr *pkt_hdr,
+					size_t len,
+					process_packet_cb cb)
+{
+	const struct silvair_rx_evt_hdr *rx_hdr;
+	const struct silvair_rx_evt_pld *rx_pld;
+	const uint8_t *adv;
+	int8_t rssi;
+
+	if (len < sizeof(*rx_hdr))
+		return;
+
+	rx_hdr = (struct silvair_rx_evt_hdr *)(pkt_hdr + 1);
+	len -= sizeof(*rx_hdr);
+
+	if (len < sizeof(*rx_pld))
+		return;
+
+	rssi = rx_hdr->rssi;
+
+	rx_pld = (struct silvair_rx_evt_pld *)(rx_hdr + 1);
+
+	adv = rx_pld->adv_data;
+
+	while (adv < (const uint8_t *)rx_pld + pkt_hdr->pld_len) {
+		uint8_t field_len = adv[0];
+
+		/* Check for the end of advertising data */
+		if (field_len == 0)
+			break;
+
+		/* Do not continue data parsing if got incorrect length */
+		if (adv + field_len + 1 >
+			(const uint8_t *)rx_pld + pkt_hdr->pld_len)
+			break;
+
+		cb(io->pvt, rssi, instant, adv + 1, field_len);
+
+		adv += field_len + 1;
+	}
+}
+
+void silvair_process_packet(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, process_packet_cb cb)
+{
+	const struct silvair_pkt_hdr *pkt_hdr;
+	size_t len = size;
+
+	if (len < sizeof(*pkt_hdr))
+		return;
+
+	pkt_hdr = (struct silvair_pkt_hdr *)buf;
+	len -= sizeof(*pkt_hdr);
+
+	switch (pkt_hdr->type) {
+	case SILVAIR_EVT_RX:
+		process_evt_rx(io, instant, pkt_hdr, len, cb);
+		break;
+	case SILVAIR_EVT_RESET:
+	case SILVAIR_CMD_TX:
+	case SILVAIR_CMD_RX:
+	case SILVAIR_CMD_BOOTLOADER:
+	case SILVAIR_CMD_FILTER:
+		break;
+	}
+}
+
+void silvair_process_slip(struct mesh_io *io, struct slip *slip,
+					uint8_t *buf, size_t size,
+					uint32_t instant, process_packet_cb cb)
+{
+	for (uint8_t *i = buf; i != buf + size; ++i) {
+		switch (*i) {
+		case SLIP_END:
+			if (slip->offset)
+				silvair_process_packet(io, slip->buf,
+							slip->offset, instant,
+							cb);
+
+			slip->offset = 0;
+			break;
+
+		case SLIP_ESC:
+			slip->esc = true;
+			break;
+
+		default:
+			if (!slip->esc) {
+				slip->buf[slip->offset++] = *i;
+				break;
+			}
+
+			switch (*i) {
+			case SLIP_ESC_ESC:
+				slip->buf[slip->offset++] = SLIP_ESC;
+				break;
+
+			case SLIP_ESC_END:
+				slip->buf[slip->offset++] = SLIP_END;
+				break;
+
+			default:
+				slip->offset = 0;
+			}
+
+			slip->esc = false;
+		}
+	}
+}
+
+static bool slip_write(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb)
+{
+	static const uint8_t end = SLIP_END;
+	static const uint8_t esc_end[2] = { SLIP_ESC, SLIP_ESC_END };
+	static const uint8_t esc_esc[2] = { SLIP_ESC, SLIP_ESC_ESC };
+
+	if (!cb(io->pvt, instant, &end, 1))
+		return false;
+
+	for (uint8_t *i = buf; i != buf + size; ++i) {
+		switch (*i) {
+		case SLIP_END:
+			if (!cb(io->pvt, instant, esc_end, 2))
+				return false;
+			break;
+
+		case SLIP_ESC:
+			if (!cb(io->pvt, instant, esc_esc, 2))
+				return false;
+			break;
+
+		default:
+			if (cb(io->pvt, instant, i, 1) != 1)
+				return false;
+		}
+	}
+
+	if (!cb(io->pvt, instant, &end, 1))
+		return false;
+
+	return true;
+}
+
+static bool simple_write(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb)
+{
+	return cb(io->pvt, instant, buf, size);
+}
+
+
+static bool send_packet(struct mesh_io *io, uint8_t *buf, size_t size,
+				uint32_t instant,
+				write_cb write, send_data_cb cb)
+{
+	uint8_t data[512] = { 0 };
+	struct silvair_pkt_hdr *pkt_hdr;
+	struct silvair_tx_cmd_hdr *tx_hdr;
+	struct silvair_tx_cmd_pld *tx_pld;
+	uint8_t *adv_data;
+	int len;
+
+	pkt_hdr = (struct silvair_pkt_hdr *)data;
+	tx_hdr = (struct silvair_tx_cmd_hdr *)(pkt_hdr + 1);
+	tx_pld = (struct silvair_tx_cmd_pld *)(tx_hdr + 1);
+	adv_data = tx_pld->adv_data;
+
+	pkt_hdr->hdr_len = sizeof(*pkt_hdr);
+	pkt_hdr->pld_len = sizeof(*tx_hdr) + sizeof(*tx_pld) +
+							size + 1;
+	pkt_hdr->version = 1;
+	pkt_hdr->counter = 0; // TODO: L_CPU_TO_BE16(pvt->counter);
+	pkt_hdr->type = SILVAIR_CMD_TX;
+
+	tx_hdr->hdr_len = sizeof(*tx_hdr);
+	tx_hdr->channels[3] = 0xe0;
+	tx_hdr->phy = SILVAIR_PHY_1MBIT;
+	tx_hdr->pwr = SILVAIR_PWR_MINUS_8_DBM;
+
+	tx_pld->access_address = L_CPU_TO_BE32(0x8e89bed6);
+	/* ADV_NOCONN_IND */
+	tx_pld->header.type = 2;
+
+	/* bdaddress + type tag + data */
+	tx_pld->header.size = 6 + size + 1;
+	tx_hdr->counter = 0; // TODO: L_CPU_TO_BE16(pvt->counter + 1);
+
+	l_getrandom(tx_pld->address, sizeof(tx_pld->address));
+	tx_pld->address[5] |= 0xc0;
+
+	adv_data[0] = size;
+	memcpy(adv_data + 1, buf, size);
+
+	len = pkt_hdr->hdr_len + pkt_hdr->pld_len;
+
+	return write(io, data, len, instant, cb);
+}
+
+bool silvair_send_packet(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb)
+{
+	return send_packet(io, buf, size, instant, simple_write, cb);
+}
+
+bool silvair_send_slip(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb)
+{
+	return send_packet(io, buf, size, instant, slip_write, cb);
+}

--- a/mesh/silvair-io.c
+++ b/mesh/silvair-io.c
@@ -217,6 +217,12 @@ void silvair_process_slip(struct mesh_io *io, struct slip *slip,
 
 			slip->esc = false;
 		}
+
+		if (slip->offset >= sizeof(slip->buf)) {
+			slip->offset = 0;
+			slip->esc = false;
+			return;
+		}
 	}
 }
 

--- a/mesh/silvair-io.h
+++ b/mesh/silvair-io.h
@@ -1,0 +1,50 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+struct mesh_io;
+struct mesh_io_private;
+
+struct slip {
+	uint8_t buf[512];
+	size_t offset;
+	bool esc;
+};
+
+typedef void (*process_packet_cb)(struct mesh_io_private *pvt, int8_t rssi,
+					uint32_t instant,
+					const uint8_t *data, uint8_t len);
+
+typedef bool (*send_data_cb)(struct mesh_io_private *pvt, uint32_t instant,
+					const uint8_t *data, size_t len);
+
+void silvair_process_packet(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, process_packet_cb cb);
+
+void silvair_process_slip(struct mesh_io *io, struct slip *slip,
+					uint8_t *buf, size_t size,
+					uint32_t instant, process_packet_cb cb);
+
+bool silvair_send_packet(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb);
+
+bool silvair_send_slip(struct mesh_io *io, uint8_t *buf, size_t size,
+					uint32_t instant, send_data_cb cb);


### PR DESCRIPTION
The server accepts a single connection on a given port: when a client is connected, all subsequent connections are immediately dropped.

The protocol uses the same SLIP framing and protocol format as `mesh-io-silvair` over UART.