### PR TITLE
mesh: Change API to deliver tokens via JoinComplete

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,14 @@ gdbus_libgdbus_internal_la_SOURCES = gdbus/gdbus.h \
 				gdbus/mainloop.c gdbus/watch.c \
 				gdbus/object.c gdbus/client.c gdbus/polkit.c
 
+if OPENSSL
+openssl_cflags = @OPENSSL_CFLAGS@
+openssl_ldadd = @OPENSSL_LIBS@
+else
+openssl_cflags =
+openssl_ldadd =
+endif
+
 if EXTERNAL_ELL
 ell_cflags = @ELL_CFLAGS@
 ell_ldadd = @ELL_LIBS@
@@ -541,7 +549,7 @@ unit_tests += unit/test-mesh-crypto
 unit_test_mesh_crypto_CPPFLAGS = $(ell_cflags)
 unit_test_mesh_crypto_SOURCES = unit/test-mesh-crypto.c \
 				mesh/crypto.h ell/internal ell/ell.h
-unit_test_mesh_crypto_LDADD = $(ell_ldadd)
+unit_test_mesh_crypto_LDADD = $(ell_ldadd) ${openssl_ldadd}
 endif
 
 if MAINTAINER_MODE

--- a/Makefile.am
+++ b/Makefile.am
@@ -96,13 +96,8 @@ gdbus_libgdbus_internal_la_SOURCES = gdbus/gdbus.h \
 				gdbus/mainloop.c gdbus/watch.c \
 				gdbus/object.c gdbus/client.c gdbus/polkit.c
 
-if OPENSSL
 openssl_cflags = @OPENSSL_CFLAGS@
 openssl_ldadd = @OPENSSL_LIBS@
-else
-openssl_cflags =
-openssl_ldadd =
-endif
 
 if EXTERNAL_ELL
 ell_cflags = @ELL_CFLAGS@
@@ -144,7 +139,9 @@ ell_headers = ell/util.h \
 			ell/asn1-private.h \
 			ell/pkcs5-private.h \
 			ell/cert-private.h \
-			ell/pem-private.h
+			ell/pem-private.h \
+			ell/ringbuf.h
+
 
 ell_sources = ell/private.h ell/missing.h \
 			ell/util.c \
@@ -179,7 +176,8 @@ ell_sources = ell/private.h ell/missing.h \
 			ell/gvariant-private.h \
 			ell/gvariant-util.c \
 			ell/siphash-private.h \
-			ell/siphash.c
+			ell/siphash.c \
+			ell/ringbuf.c
 
 ell_libell_internal_la_SOURCES = $(ell_headers) $(ell_sources)
 endif

--- a/Makefile.mesh
+++ b/Makefile.mesh
@@ -40,7 +40,8 @@ mesh/mesh.$(OBJEXT): ell/internal
 mesh/main.$(OBJEXT): src/builtin.h lib/bluetooth/bluetooth.h
 
 mesh_bluetooth_meshd_SOURCES = $(mesh_sources) mesh/main.c
-mesh_bluetooth_meshd_LDADD = src/libshared-ell.la $(ell_ldadd) -ljson-c
+mesh_bluetooth_meshd_LDADD = src/libshared-ell.la $(ell_ldadd) -ljson-c \
+							$(openssl_ldadd)
 mesh_bluetooth_meshd_DEPENDENCIES = $(ell_dependencies) src/libshared-ell.la \
 				mesh/bluetooth-mesh.service
 

--- a/Makefile.mesh
+++ b/Makefile.mesh
@@ -14,8 +14,14 @@ mesh_sources = mesh/mesh.h mesh/mesh.c \
 				mesh/mesh-io.h mesh/mesh-io.c \
 				mesh/mesh-mgmt.c mesh/mesh-mgmt.h \
 				mesh/error.h mesh/mesh-io-api.h \
+				mesh/silvair-io.h \
+				mesh/silvair-io.c \
 				mesh/mesh-io-generic.h \
 				mesh/mesh-io-generic.c \
+				mesh/mesh-io-uart.h \
+				mesh/mesh-io-uart.c \
+				mesh/mesh-io-tcpserver.h \
+				mesh/mesh-io-tcpserver.c \
 				mesh/net.h mesh/net.c \
 				mesh/crypto.h mesh/crypto.c \
 				mesh/friend.h mesh/friend.c \

--- a/Makefile.mesh
+++ b/Makefile.mesh
@@ -20,6 +20,10 @@ mesh_sources = mesh/mesh.h mesh/mesh.c \
 				mesh/mesh-io-generic.c \
 				mesh/mesh-io-uart.h \
 				mesh/mesh-io-uart.c \
+				mesh/conn-stat.c \
+				mesh/conn-stat.h \
+				mesh/tcpserver-acl.c \
+				mesh/tcpserver-acl.h \
 				mesh/mesh-io-tcpserver.h \
 				mesh/mesh-io-tcpserver.c \
 				mesh/net.h mesh/net.c \

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -339,6 +339,7 @@ tools_mesh_cfgclient_SOURCES = tools/mesh-cfgclient.c \
 				mesh/crypto.h mesh/crypto.c
 
 tools_mesh_cfgclient_LDADD = lib/libbluetooth-internal.la src/libshared-ell.la \
+						$(openssl_ldadd) \
 						$(ell_ldadd) -ljson-c -lreadline
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -403,4 +403,17 @@ fi
 AC_DEFINE_UNQUOTED(ANDROID_STORAGEDIR, "${storagedir}/android",
 			[Directory for the Android daemon storage files])
 
+AC_ARG_ENABLE(openssl, AC_HELP_STRING([--enable-openssl],
+		[enable openssl]), [enable_openssl=${enableval}])
+AM_CONDITIONAL(OPENSSL, test "${enable_openssl}" = "yes")
+
+if (test "${enable_openssl}" = "yes"); then
+	AC_DEFINE(HAVE_OPENSSL, 1,
+			[Define to 1 if you have openssl support.])
+	PKG_CHECK_MODULES(OPENSSL, openssl, dummy=yes,
+				AC_MSG_ERROR(openssl is required))
+	AC_SUBST(OPENSSL_CFLAGS)
+	AC_SUBST(OPENSSL_LIBS)
+fi
+
 AC_OUTPUT(Makefile src/bluetoothd.8 lib/bluez.pc)

--- a/configure.ac
+++ b/configure.ac
@@ -403,17 +403,11 @@ fi
 AC_DEFINE_UNQUOTED(ANDROID_STORAGEDIR, "${storagedir}/android",
 			[Directory for the Android daemon storage files])
 
-AC_ARG_ENABLE(openssl, AC_HELP_STRING([--enable-openssl],
-		[enable openssl]), [enable_openssl=${enableval}])
-AM_CONDITIONAL(OPENSSL, test "${enable_openssl}" = "yes")
-
-if (test "${enable_openssl}" = "yes"); then
-	AC_DEFINE(HAVE_OPENSSL, 1,
+AC_DEFINE(HAVE_OPENSSL, 1,
 			[Define to 1 if you have openssl support.])
-	PKG_CHECK_MODULES(OPENSSL, openssl, dummy=yes,
-				AC_MSG_ERROR(openssl is required))
-	AC_SUBST(OPENSSL_CFLAGS)
-	AC_SUBST(OPENSSL_LIBS)
-fi
+PKG_CHECK_MODULES(OPENSSL, openssl, dummy=yes,
+			AC_MSG_ERROR(openssl is required))
+AC_SUBST(OPENSSL_CFLAGS)
+AC_SUBST(OPENSSL_LIBS)
 
 AC_OUTPUT(Makefile src/bluetoothd.8 lib/bluez.pc)

--- a/doc/mesh-adapter-api.txt
+++ b/doc/mesh-adapter-api.txt
@@ -1,0 +1,108 @@
+BlueZ D-Bus Mesh Adapter API description
+********************************
+
+Overview
+========
+
+This document describes API for a mesh-io (e.g. `tcpserver`) configuration.
+
+
+AccessControlList Hierarchy
+===========================
+Service		org.bluez.mesh
+Interface	org.bluez.mesh.AccessControlList1
+Object path	/org/bluez/mesh/{tcpserver_<port>}
+                                where <port> is a TCP port on which
+                                TCP server is listening.
+
+Methods:
+    uint64 token GrantAccess(array{byte}[16] uuid,
+                             array{byte}[16] dev_key,
+                             array{byte}[16] net_key)
+
+        Grants access to an internal TCP server for a TLS Client defined by
+        its UUID & device and network key. Computes an identity and
+        a pre-shared key based on these arguments. Computed values with an
+        randomly generated token are permanently stored in the configuration
+        file as an ACL entry.
+
+        The token parameter is a 64-bit number that has been assigned to
+        the access entry when it was created. The daemon uses the token
+        to verify whether the application is authorized revoke access.
+
+        array{byte}[16] uuid
+
+            UUID of the TLS Client.
+
+        array{byte}[16] dev_key
+
+            Device Key of the TLS Client.
+
+        array{byte}[16] net_key
+
+            Primary Network Key of the TLS Client (device must be provisioned).
+
+        PossibleErrors:
+            org.bluez.mesh.Error.AlreadyExists
+            org.bluez.mesh.Error.InvalidArguments
+            org.bluez.mesh.Error.Failed
+
+    void RevokeAccess(uint64 token)
+
+        Removes the ACL entry identified by the 64-bit token parameter.
+        The token parameter has been obtained as a result of successful
+        GrantAccess() method call.
+
+        PossibleErrors:
+            org.bluez.mesh.Error.InvalidArguments
+            org.bluez.mesh.Error.NotFound
+            org.bluez.mesh.Error.Failed
+
+
+Connection State Hierarchy
+==========================
+Service		org.bluez.mesh
+Interface	org.bluez.mesh.ConnectionState1
+Object path	/org/bluez/mesh/<adapter>/<identity>
+                where <adapter> is an adapter identifier e.g. {tcpserver_65254}
+                <identity> is client TLS identity hint, calculated after
+                calling GrantAccess() method.
+
+Properties:
+    bool Connected [read-only]
+
+        This property indicates if the mesh adapter is connected.
+
+    string LastError [read-only]
+
+        This property indicates last error.
+
+        The defined values are: "none", "handshake-error"
+
+    uint64 TransmittedMsgCount [read-only]
+
+        This property indicates count of transmitted messages.
+
+    uint64 ReceivedMsgCount [read-only]
+
+        This property indicates count of received messages.
+
+    uint64 LastTransmittedMsgTimestamp [read-only]
+
+        This property indicates timestamp of last transmitted message.
+
+    uint64 LastReceivedMsgTimestamp [read-only]
+
+        This property indicates timestamp of last received message.
+
+    uint64 DroppedTransmittedMsgCount [read-only]
+
+        This property indicates count of dropped transmitted messages.
+
+    uint64 DroppedReceivedMsgCount [read-only]
+
+        This property indicates count of dropped received messages.
+
+    string AdditionalInformation [read-only] [optional]
+
+        This property contains additional information about mesh adapter.

--- a/doc/mesh-api.txt
+++ b/doc/mesh-api.txt
@@ -388,6 +388,18 @@ Methods:
 			org.bluez.mesh.Error.DoesNotExist
 			org.bluez.mesh.Error.InvalidArguments
 
+	void UpdateSequenceNumber(uint32_t seq_num)
+
+		This method is used to update sequence number.
+
+		The seq_num is a 24-bit value. When the given seq_num is lower
+		than current sequence number, the value will not be updated and
+		current sequence number will be returned.
+
+		Possible errors:
+			org.bluez.mesh.Error.NotAuthorized
+			org.bluez.mesh.Error.InvalidArguments
+
 Properties:
 	dict Features [read-only]
 

--- a/mesh/bluetooth-mesh.conf
+++ b/mesh/bluetooth-mesh.conf
@@ -14,6 +14,8 @@
     <allow send_interface="org.bluez.mesh.Element1"/>
     <allow send_interface="org.bluez.mesh.ProvisionAgent1"/>
     <allow send_interface="org.bluez.mesh.Provisioner1"/>
+    <allow send_interface="org.bluez.mesh.AccessControlList1"/>
+    <allow send_interface="org.bluez.mesh.ConnectionStat1"/>
   </policy>
 
   <policy context="default">

--- a/mesh/conn-stat.c
+++ b/mesh/conn-stat.c
@@ -1,0 +1,244 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2020  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#include <time.h>
+
+#include <ell/ell.h>
+
+#include "mesh/conn-stat.h"
+#include "mesh/dbus.h"
+#include "mesh/util.h"
+
+
+static const char *PROPERTY_CONNECTED = "Connected";
+static const char *PROPERTY_LAST_ERROR = "LastError";
+static const char *PROPERTY_TX_MSG_CNT = "TransmittedMsgCount";
+static const char *PROPERTY_RX_MSG_CNT = "ReceivedMsgCount";
+static const char *PROPERTY_LAST_TX_MSG_TS = "LastTransmittedMsgTimestamp";
+static const char *PROPERTY_LAST_RX_MSG_TS = "LastReceivedMsgTimestamp";
+
+static const char *CONN_STAT_IFACE = "org.bluez.mesh.ConnectionStat1"
+;
+
+
+static bool connected_getter(struct l_dbus *dbus,
+			     struct l_dbus_message *message,
+			     struct l_dbus_message_builder *builder,
+			     void *user_data)
+{
+	struct conn_stat *conn_stat = user_data;
+
+	return l_dbus_message_builder_append_basic(builder, 'b',
+						   &conn_stat->connected);
+}
+
+static bool last_error_getter(struct l_dbus *dbus,
+					struct l_dbus_message *message,
+					struct l_dbus_message_builder *builder,
+					void *user_data)
+{
+	struct conn_stat *conn_stat = user_data;
+
+	if (!conn_stat->last_error)
+		return false;
+
+	return l_dbus_message_builder_append_basic(builder, 's',
+						   conn_stat->last_error);
+}
+
+static bool transmitted_msg_count_getter(struct l_dbus *dbus,
+					struct l_dbus_message *message,
+					struct l_dbus_message_builder *builder,
+					void *user_data)
+{
+	struct conn_stat *conn_stat = user_data;
+
+	return l_dbus_message_builder_append_basic(builder, 't',
+						   &conn_stat->tx_msgs_cnt);
+}
+
+static bool received_msg_count_getter(struct l_dbus *dbus,
+					struct l_dbus_message *message,
+					struct l_dbus_message_builder *builder,
+					void *user_data)
+{
+	struct conn_stat *conn_stat = user_data;
+
+	return l_dbus_message_builder_append_basic(builder, 't',
+						   &conn_stat->rx_msgs_cnt);
+}
+
+static bool last_transmitted_msg_timestamp_getter(struct l_dbus *dbus,
+					struct l_dbus_message *message,
+					struct l_dbus_message_builder *builder,
+					void *user_data)
+{
+	struct conn_stat *conn_stat = user_data;
+
+	return l_dbus_message_builder_append_basic(builder, 't',
+					   &conn_stat->last_tx_msg_timestamp);
+}
+
+static bool last_received_msg_timestamp_getter(struct l_dbus *dbus,
+					struct l_dbus_message *message,
+					struct l_dbus_message_builder *builder,
+					void *user_data)
+{
+	struct conn_stat *conn_stat = user_data;
+
+	return l_dbus_message_builder_append_basic(builder, 't',
+					&conn_stat->last_rx_msg_timestamp);
+}
+
+static void setup_adpt_status_iface(struct l_dbus_interface *iface)
+{
+	l_dbus_interface_property(iface, PROPERTY_CONNECTED, 0, "b",
+				  connected_getter, NULL);
+
+	l_dbus_interface_property(iface, PROPERTY_LAST_ERROR, 0, "s",
+				  last_error_getter, NULL);
+
+	l_dbus_interface_property(iface, PROPERTY_TX_MSG_CNT, 0, "t",
+				  transmitted_msg_count_getter, NULL);
+
+	l_dbus_interface_property(iface, PROPERTY_RX_MSG_CNT, 0, "t",
+				  received_msg_count_getter, NULL);
+
+	l_dbus_interface_property(iface, PROPERTY_LAST_TX_MSG_TS, 0, "t",
+				  last_transmitted_msg_timestamp_getter, NULL);
+
+	l_dbus_interface_property(iface, PROPERTY_LAST_RX_MSG_TS, 0, "t",
+				  last_received_msg_timestamp_getter, NULL);
+}
+
+bool conn_stat_dbus_init(struct l_dbus *bus)
+{
+	if (!l_dbus_register_interface(bus, CONN_STAT_IFACE,
+				       setup_adpt_status_iface, NULL, false)) {
+
+		l_info("Unable to register %s interface",
+		       CONN_STAT_IFACE);
+
+		return false;
+	}
+
+	return true;
+}
+
+static bool create_dbus_object(struct conn_stat *conn_stat)
+{
+	if (!l_dbus_object_add_interface(conn_stat->dbus,
+					 conn_stat->dbus_path,
+					 L_DBUS_INTERFACE_PROPERTIES,
+					 conn_stat)) {
+		l_error("Failed to add D-Bus interface: '%s' to object: '%s'",
+			L_DBUS_INTERFACE_PROPERTIES, conn_stat->dbus_path);
+
+		return false;
+	}
+
+	if (!l_dbus_object_add_interface(conn_stat->dbus,
+					 conn_stat->dbus_path,
+					 CONN_STAT_IFACE, conn_stat)) {
+		l_error("Failed to add D-Bus interface: '%s' to object: '%s'",
+			CONN_STAT_IFACE, conn_stat->dbus_path);
+
+		return false;
+	}
+
+	return true;
+}
+
+static void destroy_dbus_object(struct conn_stat *conn_stat)
+{
+	l_dbus_object_remove_interface(conn_stat->dbus,
+				       conn_stat->dbus_path,
+				       L_DBUS_INTERFACE_PROPERTIES);
+
+	l_dbus_object_remove_interface(conn_stat->dbus,
+				       conn_stat->dbus_path,
+				       CONN_STAT_IFACE);
+
+	l_dbus_unregister_object(conn_stat->dbus, conn_stat->dbus_path);
+
+	conn_stat->dbus = NULL;
+}
+
+struct conn_stat *conn_stat_new(struct l_dbus *dbus,
+				const char *adapter_dbus_path, const char *name)
+{
+	struct conn_stat *conn_stat;
+
+	conn_stat = l_new(struct conn_stat, 1);
+
+	conn_stat->dbus		= dbus;
+	conn_stat->dbus_path	= l_strdup_printf("%s/%s",
+						      adapter_dbus_path, name);
+
+	if (!create_dbus_object(conn_stat)) {
+		l_error("Failed to create D-Bus object.");
+		goto fail;
+	}
+
+	return conn_stat;
+
+fail:
+	conn_stat_destroy(conn_stat);
+	return NULL;
+}
+
+void conn_stat_destroy(struct conn_stat *conn_stat)
+{
+	destroy_dbus_object(conn_stat);
+
+	if (conn_stat->dbus_path)
+		l_free(conn_stat->dbus_path);
+
+	l_free(conn_stat);
+}
+
+void conn_stat_connected_set(struct conn_stat *conn_stat, bool connected)
+{
+	if (conn_stat->connected == connected)
+		return;
+
+	if (connected) {
+		conn_stat->tx_msgs_cnt = 0;
+		conn_stat->rx_msgs_cnt = 0;
+		conn_stat->last_tx_msg_timestamp = 0;
+		conn_stat->last_rx_msg_timestamp = 0;
+	}
+
+	conn_stat->connected = connected;
+
+	l_dbus_property_changed(conn_stat->dbus, conn_stat->dbus_path,
+					CONN_STAT_IFACE, PROPERTY_CONNECTED);
+
+}
+
+void conn_stat_message_sent(struct conn_stat *conn_stat)
+{
+	conn_stat->tx_msgs_cnt++;
+	conn_stat->last_tx_msg_timestamp = time(NULL);
+}
+
+void conn_stat_message_received(struct conn_stat *conn_stat)
+{
+	conn_stat->rx_msgs_cnt++;
+	conn_stat->last_rx_msg_timestamp = time(NULL);
+}

--- a/mesh/conn-stat.h
+++ b/mesh/conn-stat.h
@@ -1,0 +1,49 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2020  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <ell/dbus.h>
+
+
+struct conn_stat {
+	char		*dbus_path;
+	struct l_dbus	*dbus;
+
+	bool		connected;
+	const char	*last_error;
+	uint64_t	tx_msgs_cnt;
+	uint64_t	rx_msgs_cnt;
+	uint64_t	last_tx_msg_timestamp;
+	uint64_t	last_rx_msg_timestamp;
+};
+
+
+struct conn_stat *conn_stat_new(struct l_dbus *dbus,
+			const char *adapter_dbus_path, const char *name);
+
+void conn_stat_destroy(struct conn_stat *conn_stat);
+
+bool conn_stat_dbus_init(struct l_dbus *bus);
+
+void conn_stat_connected_set(struct conn_stat *conn_stat, bool connected);
+
+void conn_stat_message_sent(struct conn_stat *conn_stat);
+
+void conn_stat_message_received(struct conn_stat *conn_stat);

--- a/mesh/crypto.c
+++ b/mesh/crypto.c
@@ -49,18 +49,6 @@ static bool aes_ecb_one(const uint8_t key[16], const uint8_t in[16],
 	return result;
 }
 
-static bool aes_cmac(void *checksum, const uint8_t *msg,
-					size_t msg_len, uint8_t res[16])
-{
-	if (!l_checksum_update(checksum, msg, msg_len))
-		return false;
-
-	if (16 == l_checksum_get_digest(checksum, res, 16))
-		return true;
-
-	return false;
-}
-
 static bool aes_cmac_one(const uint8_t key[16], const void *msg,
 					size_t msg_len, uint8_t res[16])
 {
@@ -161,7 +149,6 @@ bool mesh_crypto_k2(const uint8_t n[16], const uint8_t *p, size_t p_len,
 							uint8_t enc_key[16],
 							uint8_t priv_key[16])
 {
-	void *checksum;
 	uint8_t output[16];
 	uint8_t t[16];
 	uint8_t *stage;
@@ -172,19 +159,15 @@ bool mesh_crypto_k2(const uint8_t n[16], const uint8_t *p, size_t p_len,
 		return false;
 
 	if (!mesh_crypto_s1("smk2", 4, stage))
-		goto fail;
+		goto done;
 
 	if (!aes_cmac_one(stage, n, 16, t))
-		goto fail;
-
-	checksum = l_checksum_new_cmac_aes(t, 16);
-	if (!checksum)
-		goto fail;
+		goto done;
 
 	memcpy(stage, p, p_len);
 	stage[p_len] = 1;
 
-	if (!aes_cmac(checksum, stage, p_len + 1, output))
+	if (!aes_cmac_one(t, stage, p_len + 1, output))
 		goto done;
 
 	net_id[0] = output[15] & 0x7f;
@@ -193,7 +176,7 @@ bool mesh_crypto_k2(const uint8_t n[16], const uint8_t *p, size_t p_len,
 	memcpy(stage + 16, p, p_len);
 	stage[p_len + 16] = 2;
 
-	if (!aes_cmac(checksum, stage, p_len + 16 + 1, output))
+	if (!aes_cmac_one(t, stage, p_len + 16 + 1, output))
 		goto done;
 
 	memcpy(enc_key, output, 16);
@@ -202,15 +185,13 @@ bool mesh_crypto_k2(const uint8_t n[16], const uint8_t *p, size_t p_len,
 	memcpy(stage + 16, p, p_len);
 	stage[p_len + 16] = 3;
 
-	if (!aes_cmac(checksum, stage, p_len + 16 + 1, output))
+	if (!aes_cmac_one(t, stage, p_len + 16 + 1, output))
 		goto done;
 
 	memcpy(priv_key, output, 16);
 	success = true;
 
 done:
-	l_checksum_free(checksum);
-fail:
 	l_free(stage);
 
 	return success;

--- a/mesh/crypto.c
+++ b/mesh/crypto.c
@@ -29,9 +29,170 @@
 #include "mesh/mesh-defs.h"
 #include "mesh/net.h"
 #include "mesh/crypto.h"
+#include "mesh/util.h"
 
-/* Multiply used Zero array */
-static const uint8_t zero[16] = { 0, };
+#if HAVE_OPENSSL
+
+#include <openssl/conf.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/cmac.h>
+
+static bool aes_ecb_one(const uint8_t key[16], const uint8_t in[16],
+								uint8_t out[16])
+{
+	int len;
+	bool result = false;
+	EVP_CIPHER_CTX *cipher = EVP_CIPHER_CTX_new();
+
+	if (!cipher)
+		return false;
+
+	if (!EVP_EncryptInit_ex(cipher, EVP_aes_128_ecb(), NULL, key, NULL))
+		goto done;
+
+	if (!EVP_EncryptUpdate(cipher, out, &len, in, 16))
+		goto done;
+
+	result = true;
+
+done:
+	EVP_CIPHER_CTX_cleanup(cipher);
+	return result;
+}
+
+static bool aes_cmac_one(const uint8_t key[16], const void *msg,
+					size_t msg_len, uint8_t res[16])
+{
+	bool result = false;
+	size_t res_len;
+	CMAC_CTX *checksum = CMAC_CTX_new();
+
+	if (!checksum)
+		return false;
+
+	if (!CMAC_Init(checksum, key, 16, EVP_aes_128_cbc(), NULL))
+		goto done;
+
+	if (!CMAC_Update(checksum, msg, msg_len))
+		goto done;
+
+	if (!CMAC_Final(checksum, res, &res_len))
+		goto done;
+
+	result = !!(res_len == 16);
+
+done:
+	CMAC_CTX_free(checksum);
+	return result;
+}
+
+bool mesh_crypto_aes_ccm_encrypt(const uint8_t nonce[13], const uint8_t key[16],
+					const uint8_t *aad, uint16_t aad_len,
+					const void *msg, uint16_t msg_len,
+					void *out_msg,
+					void *out_mic, size_t mic_size)
+{
+	int len;
+	int out_len;
+	bool result = false;
+	EVP_CIPHER_CTX *cipher = EVP_CIPHER_CTX_new();
+
+	if (!cipher)
+		return false;
+
+	if (!EVP_EncryptInit_ex(cipher, EVP_aes_128_ccm(), NULL, NULL, NULL))
+		goto done;
+
+	EVP_CIPHER_CTX_ctrl(cipher, EVP_CTRL_CCM_SET_TAG, mic_size, NULL);
+	EVP_CIPHER_CTX_ctrl(cipher, EVP_CTRL_CCM_SET_IVLEN, 13, NULL);
+
+	if (!EVP_EncryptInit_ex(cipher, NULL, NULL, key, nonce))
+		goto done;
+
+	if (!EVP_EncryptUpdate(cipher, NULL, &len, NULL, msg_len))
+		goto done;
+
+	if (aad && !EVP_EncryptUpdate(cipher, NULL, &len, aad, aad_len))
+		goto done;
+
+	if (!EVP_EncryptUpdate(cipher, out_msg, &out_len, msg, msg_len))
+		goto done;
+
+	EVP_CIPHER_CTX_ctrl(cipher, EVP_CTRL_CCM_GET_TAG,
+						mic_size, out_msg + out_len);
+
+	if (out_mic) {
+		if (mic_size == 4)
+			*(uint32_t *)out_mic = l_get_be32(out_msg + out_len);
+		else
+			*(uint64_t *)out_mic = l_get_be64(out_msg + out_len);
+	}
+
+	out_len += mic_size;
+	result = true;
+
+done:
+	EVP_CIPHER_CTX_cleanup(cipher);
+	return result;
+}
+
+bool mesh_crypto_aes_ccm_decrypt(const uint8_t nonce[13], const uint8_t key[16],
+				const uint8_t *aad, uint16_t aad_len,
+				const void *enc_msg, uint16_t enc_msg_len,
+				void *out_msg,
+				void *out_mic, size_t mic_size)
+{
+	int len;
+	int out_len;
+	bool result = false;
+	EVP_CIPHER_CTX *cipher = EVP_CIPHER_CTX_new();
+
+	if (!cipher)
+		return false;
+
+	enc_msg_len -= mic_size;
+
+	if (!EVP_DecryptInit_ex(cipher, EVP_aes_128_ccm(), NULL, NULL, NULL))
+		goto done;
+
+	EVP_CIPHER_CTX_ctrl(cipher, EVP_CTRL_CCM_SET_IVLEN, 13, NULL);
+
+	EVP_CIPHER_CTX_ctrl(cipher, EVP_CTRL_CCM_SET_TAG, mic_size,
+						(void *)enc_msg + enc_msg_len);
+
+	if (!EVP_DecryptInit_ex(cipher, NULL, NULL, key, nonce))
+		goto done;
+
+	if (!EVP_DecryptUpdate(cipher, NULL, &len, NULL, enc_msg_len))
+		goto done;
+
+	if (aad && !EVP_DecryptUpdate(cipher, NULL, &len, aad, aad_len))
+		goto done;
+
+	if (!EVP_DecryptUpdate(cipher, out_msg, &out_len, enc_msg,
+								enc_msg_len))
+		goto done;
+
+	memcpy(out_msg + out_len, enc_msg + enc_msg_len, mic_size);
+
+	if (out_mic) {
+		if (mic_size == 4)
+			*(uint32_t *)out_mic =
+				l_get_be32(enc_msg + enc_msg_len);
+		else
+			*(uint64_t *)out_mic =
+				l_get_be64(enc_msg + enc_msg_len);
+	}
+
+	result = true;
+
+done:
+	EVP_CIPHER_CTX_cleanup(cipher);
+	return result;
+}
+
+#else
 
 static bool aes_ecb_one(const uint8_t key[16], const uint8_t in[16],
 								uint8_t out[16])
@@ -69,12 +230,6 @@ static bool aes_cmac_one(const uint8_t key[16], const void *msg,
 	l_checksum_free(checksum);
 
 	return result;
-}
-
-bool mesh_crypto_aes_cmac(const uint8_t key[16], const uint8_t *msg,
-					size_t msg_len, uint8_t res[16])
-{
-	return aes_cmac_one(key, msg, msg_len, res);
 }
 
 bool mesh_crypto_aes_ccm_encrypt(const uint8_t nonce[13], const uint8_t key[16],
@@ -133,8 +288,19 @@ bool mesh_crypto_aes_ccm_decrypt(const uint8_t nonce[13], const uint8_t key[16],
 	return result;
 }
 
+#endif
+
+/* Multiply used Zero array */
+static const uint8_t zero[16] = { 0, };
+
+bool mesh_crypto_aes_cmac(const uint8_t key[16], const uint8_t *msg,
+					size_t msg_len, uint8_t res[16])
+{
+	return aes_cmac_one(key, msg, msg_len, res);
+}
+
 bool mesh_crypto_k1(const uint8_t ikm[16], const uint8_t salt[16],
-		const void *info, size_t info_len, uint8_t okm[16])
+			const void *info, size_t info_len, uint8_t okm[16])
 {
 	uint8_t res[16];
 
@@ -1008,6 +1174,9 @@ static const uint8_t crypto_test_result[] = {
 
 bool mesh_crypto_check_avail()
 {
+#if HAVE_OPENSSL
+	return true;
+#else
 	void *cipher;
 	bool result;
 	uint8_t i;
@@ -1046,4 +1215,5 @@ bool mesh_crypto_check_avail()
 	l_aead_cipher_free(cipher);
 
 	return result;
+#endif
 }

--- a/mesh/crypto.c
+++ b/mesh/crypto.c
@@ -1175,6 +1175,7 @@ static const uint8_t crypto_test_result[] = {
 bool mesh_crypto_check_avail()
 {
 #if HAVE_OPENSSL
+	(void)crypto_test_result;
 	return true;
 #else
 	void *cipher;

--- a/mesh/main.c
+++ b/mesh/main.c
@@ -70,7 +70,11 @@ static void usage(void)
 	       "io:\n"
 	       "\t([hci]<index> | generic[:[hci]<index>])\n"
 	       "\t\tUse generic HCI io on interface hci<index>, or the first\n"
-	       "\t\tavailable one\n");
+	       "\t\tavailable one\n"
+	       "\tsilvair:<tty>\n"
+	       "\t\tUse Silvair Radio SLIP protocol on <tty>\n"
+	       "\ttcpserver:<port>,<uuid>,<dev-key>,<net-key>\n"
+	       "\t\tUse Silvair Radio SLIP protocol over TCP/IP\n");
 }
 
 static void do_debug(const char *str, void *user_data)
@@ -166,6 +170,36 @@ static bool parse_io(const char *optarg, enum mesh_io_type *type, void **opts)
 			return true;
 
 		return false;
+	}
+
+	if (strstr(optarg, "silvair") == optarg) {
+		*type = MESH_IO_TYPE_UART;
+
+		optarg += strlen("silvair");
+
+		if (*optarg != ':')
+			return false;
+
+		optarg++;
+
+		*opts = l_strdup(optarg);
+
+		return true;
+	}
+
+	if (strstr(optarg, "tcpserver") == optarg) {
+		*type = MESH_IO_TYPE_TCPSERVER;
+
+		optarg += strlen("tcpserver");
+
+		if (*optarg != ':')
+			return false;
+
+		optarg++;
+
+		*opts = l_strdup(optarg);
+
+		return true;
 	}
 
 	return false;

--- a/mesh/main.c
+++ b/mesh/main.c
@@ -73,7 +73,7 @@ static void usage(void)
 	       "\t\tavailable one\n"
 	       "\tsilvair:<tty>\n"
 	       "\t\tUse Silvair Radio SLIP protocol on <tty>\n"
-	       "\ttcpserver:<port>,<uuid>,<dev-key>,<net-key>\n"
+	       "\ttcpserver:<port>\n"
 	       "\t\tUse Silvair Radio SLIP protocol over TCP/IP\n");
 }
 

--- a/mesh/mesh-config-json.c
+++ b/mesh/mesh-config-json.c
@@ -2015,6 +2015,12 @@ bool mesh_config_write_seq_number(struct mesh_config *cfg, uint32_t seq,
 		timersub(&now, &cfg->write_time, &elapsed);
 		elapsed_ms = elapsed.tv_sec * 1000 + elapsed.tv_usec / 1000;
 
+		/* If time since last write is zero, this means that
+		 * idle_save_config is already pending, so we don't need to do
+		 * anything. */
+		if (!elapsed_ms)
+			return true;
+
 		cached = seq + (seq - cfg->write_seq) *
 					1000 * MIN_SEQ_CACHE_TIME / elapsed_ms;
 

--- a/mesh/mesh-io-api.h
+++ b/mesh/mesh-io-api.h
@@ -33,6 +33,7 @@ typedef bool (*mesh_io_deregister_t)(struct mesh_io *io, const uint8_t *filter,
 								uint8_t len);
 typedef bool (*mesh_io_tx_cancel_t)(struct mesh_io *io, const uint8_t *pattern,
 								uint8_t len);
+typedef bool (*mesh_io_dbus_init_t)(struct mesh_io *io, struct l_dbus *dbus);
 
 struct mesh_io_api {
 	mesh_io_init_t		init;
@@ -42,6 +43,7 @@ struct mesh_io_api {
 	mesh_io_register_t	reg;
 	mesh_io_deregister_t	dereg;
 	mesh_io_tx_cancel_t	cancel;
+	mesh_io_dbus_init_t	dbus_init;
 };
 
 struct mesh_io {

--- a/mesh/mesh-io-tcpserver.c
+++ b/mesh/mesh-io-tcpserver.c
@@ -405,14 +405,19 @@ static unsigned int tls_psk_server_cb(SSL *ssl,
 
 static bool tls_ctx_init(struct mesh_io_private *pvt)
 {
-	int off = SSL_OP_NO_TLSv1_3 |
-				SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+	int off = SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
 
 	ERR_load_crypto_strings();
 
 	SSL_library_init();
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	off |= SSL_OP_NO_TLSv1_3;
 	pvt->tls_ctx = SSL_CTX_new(TLS_server_method());
+#else
+	pvt->tls_ctx = SSL_CTX_new(TLSv1_2_server_method());
+#endif
+
 	if (!pvt->tls_ctx) {
 		l_error("Failed to alloc TLS context object.");
 		return false;

--- a/mesh/mesh-io-tcpserver.c
+++ b/mesh/mesh-io-tcpserver.c
@@ -42,16 +42,18 @@
 
 #include "src/shared/io.h"
 
-#include "mesh/crypto.h"
+#include "mesh/mesh.h"
+#include "mesh/dbus.h"
 #include "mesh/mesh-io.h"
 #include "mesh/mesh-io-api.h"
 #include "mesh/mesh-io-tcpserver.h"
+#include "mesh/tcpserver-acl.h"
 #include "mesh/silvair-io.h"
+#include "mesh/conn-stat.h"
+#include "mesh/util.h"
 
+#define IDENTITY_LEN (16)
 
-#define UUID_LEN		(16)
-#define DEV_KEY_LEN		(16)
-#define NET_KEY_LEN		(16)
 
 static const char *tls_ciphers = "ECDHE-PSK-CHACHA20-POLY1305";
 
@@ -61,24 +63,29 @@ struct mesh_io_private {
 	mesh_io_ready_func_t ready_callback;
 
 	struct l_io		*server_io;
-	struct l_queue		*client_io;
+	struct l_queue		*conns;
 
 	struct l_timeout	*tx_timeout;
 	struct l_queue		*rx_regs;
 	struct l_queue		*tx_pkts;
 
 	/* Simple filtering on AD type only */
-	uint8_t				filters[4];
+	uint8_t			filters[4];
 	struct tx_pkt		*tx;
 
 	/* TLS context */
-	SSL_CTX				*tls_ctx;
+	SSL_CTX			*tls_ctx;
 
-	uint8_t				*uuid;
-	uint8_t				*dev_key;
-	uint8_t				*net_key;
+	const char		*dbus_path;
+	struct l_dbus		*dbus;
+	struct tcpserver_acl	*acl;
 };
 
+struct tcpserver_conn {
+	uint8_t			identity[IDENTITY_LEN];
+	struct silvair_io	*io;
+	struct conn_stat	*conn_stat;
+};
 
 struct pvt_rx_reg {
 	mesh_io_recv_func_t cb;
@@ -111,7 +118,31 @@ enum io_type {
 };
 
 static void send_timeout(struct l_timeout *timeout, void *user_data);
+static void create_conn_stat(void *data, void *user_data);
 
+static struct tcpserver_conn *tcpserver_conn_new(uint8_t *identity)
+{
+	struct tcpserver_conn *tcpserver_conn = l_new(struct tcpserver_conn, 1);
+
+	memcpy(tcpserver_conn->identity, identity,
+	       sizeof(tcpserver_conn->identity));
+
+	tcpserver_conn->conn_stat	= NULL;
+	tcpserver_conn->io		= NULL;
+
+	return tcpserver_conn;
+}
+
+static void tcpserver_conn_destroy(struct tcpserver_conn *conn)
+{
+	if (conn->conn_stat)
+		conn_stat_destroy(conn->conn_stat);
+
+	if (conn->io)
+		silvair_io_close(conn->io);
+
+	l_free(conn);
+}
 
 static uint32_t get_instant(void)
 {
@@ -125,6 +156,14 @@ static uint32_t get_instant(void)
 	return instant;
 }
 
+static bool match_tcpserver_conn_by_silvair_io(const void *a, const void *b)
+{
+	const struct tcpserver_conn *conn = a;
+	const struct silvair_io *io = b;
+
+	return conn->io == io;
+}
+
 static void process_rx_callbacks(void *v_rx, void *v_reg)
 {
 	struct pvt_rx_reg *rx_reg = v_rx;
@@ -135,10 +174,11 @@ static void process_rx_callbacks(void *v_rx, void *v_reg)
 }
 
 static void process_rx(struct silvair_io *silvair_io, int8_t rssi,
-			const uint8_t *data, uint8_t len, void *user_data)
+		       const uint8_t *data, uint8_t len, void *user_data)
 {
-	struct mesh_io *mesh_io = user_data;
-	struct process_data rx;
+	struct mesh_io		*mesh_io = user_data;
+	struct tcpserver_conn	*conn;
+	struct process_data	rx;
 
 	if (!mesh_io) {
 		l_error("mesh_io does not exist");
@@ -153,6 +193,13 @@ static void process_rx(struct silvair_io *silvair_io, int8_t rssi,
 	rx.info.rssi = rssi,
 
 	silvair_io_keep_alive_wdt_refresh(silvair_io);
+
+	conn = l_queue_find(mesh_io->pvt->conns,
+			    match_tcpserver_conn_by_silvair_io, silvair_io);
+
+	if (conn && conn->conn_stat)
+		conn_stat_message_received(conn->conn_stat);
+
 	l_queue_foreach(mesh_io->pvt->rx_regs, process_rx_callbacks, &rx);
 }
 
@@ -185,7 +232,7 @@ static bool get_fd_info(int fd, char *log, enum io_type type)
 	}
 
 	l_info("%s -> addr:%s port:%d fd:%d", log,
-			inet_ntoa(addr.sin_addr), ntohs(addr.sin_port), fd);
+	       inet_ntoa(addr.sin_addr), ntohs(addr.sin_port), fd);
 	return true;
 }
 
@@ -204,16 +251,20 @@ static void io_error_callback(struct silvair_io *silvair_io)
 static void io_disconnect_callback(struct silvair_io *silvair_io)
 {
 	struct mesh_io *mesh_io = silvair_io->context;
+	struct tcpserver_conn *conn;
 
-	if (!mesh_io->pvt->client_io)
+	if (!mesh_io->pvt->conns)
 		return;
 
-	if (!l_queue_remove(mesh_io->pvt->client_io, silvair_io)) {
-		perror("l_queue_remove() error");
-		abort();
-	}
+	conn = l_queue_find(mesh_io->pvt->conns,
+			    match_tcpserver_conn_by_silvair_io, silvair_io);
+	if (conn)
+		conn->io = NULL;
 
-	l_info("Client disconneted from TCP Server");
+	if (conn && conn->conn_stat)
+		conn_stat_connected_set(conn->conn_stat, false);
+
+	l_info("Client disconnected from TCP Server");
 	silvair_io_destroy(silvair_io);
 }
 
@@ -246,7 +297,7 @@ static bool io_accept_callback(struct l_io *l_io, void *user_data)
 	client_addrlen = sizeof(clientaddr);
 
 	newfd = accept(server_fd, (struct sockaddr *)&clientaddr,
-							&client_addrlen);
+		       &client_addrlen);
 
 	if (newfd < 0) {
 		l_error("server accept error");
@@ -255,7 +306,7 @@ static bool io_accept_callback(struct l_io *l_io, void *user_data)
 
 
 	if (fcntl(newfd, F_SETFL,
-			fcntl(newfd, F_GETFL, 0) | O_NONBLOCK) != 0) {
+		  fcntl(newfd, F_GETFL, 0) | O_NONBLOCK) != 0) {
 		l_error("client fcntl error");
 		return false;
 	}
@@ -272,28 +323,25 @@ static bool io_accept_callback(struct l_io *l_io, void *user_data)
 		l_error("Failed to create BIO object.");
 		goto error;
 	}
-
-	SSL_set_ex_data(tls_conn, 0, mesh_io->pvt);
-	SSL_set_bio(tls_conn, sbio, sbio);
-	SSL_set_accept_state(tls_conn);
-
 	get_fd_info(newfd, "New client accepted", IO_TYPE_CLIENT);
 
 	silvair_io = silvair_io_new(newfd, false, process_rx, io_error_callback,
-		io_disconnect_callback, mesh_io, tls_conn);
+				    io_disconnect_callback, mesh_io, tls_conn);
 
 	if (!silvair_io) {
 		l_error("silvair_io_new error");
 		goto error;
 	}
 
+	SSL_set_ex_data(tls_conn, 0, mesh_io);
+	SSL_set_ex_data(tls_conn, 1, silvair_io);
+	SSL_set_bio(tls_conn, sbio, sbio);
+	SSL_set_accept_state(tls_conn);
+
 	l_io_set_close_on_destroy(silvair_io->l_io, true);
 
-	l_queue_push_tail(mesh_io->pvt->client_io, silvair_io);
-
-	l_info("Connected %s:%hu",
-			inet_ntoa(clientaddr.sin_addr),
-			ntohs(clientaddr.sin_port));
+	l_info("Connected %s:%hu", inet_ntoa(clientaddr.sin_addr),
+					       ntohs(clientaddr.sin_port));
 
 	return true;
 
@@ -312,51 +360,47 @@ static void tcpserver_io_init_done(void *user_data)
 	mesh_io->pvt->ready_callback(mesh_io->pvt->user_data, true);
 }
 
-static unsigned int tls_psk_server_cb(SSL *ssl, const char *identity,
-	unsigned char *psk, unsigned int max_psk_len)
+static bool match_tcpserver_conn_by_identity(const void *a, const void *b)
 {
-	const char k1_info[] = { 'i', 'd', 'p', 's', 'k' };
-	unsigned int psk_len = 0;
+	const struct tcpserver_conn	*conn = a;
+	const uint8_t			*identity = b;
 
-	struct mesh_io_private *pvt;
-	uint8_t net_id[8];
-	char s1_info[24];
-	uint8_t id[16];
-	char *id_str;
+	return !memcmp(conn->identity, identity, sizeof(conn->identity));
+}
 
-	pvt = SSL_get_ex_data(ssl, 0);
+static unsigned int tls_psk_server_cb(SSL *ssl,
+				      const char *identity,
+				      unsigned char *psk,
+				      unsigned int max_psk_len)
+{
+	uint8_t			identity_buf[IDENTITY_LEN];
+	struct mesh_io		*mesh_io;
+	struct silvair_io	*silvair_io;
+	struct tcpserver_conn	*conn;
 
-	if (!pvt)
+	if (!str2hex(identity, strlen(identity),
+		     identity_buf, sizeof(identity_buf))) {
+		l_error("Could not convert identity str to hex.");
 		return 0;
+	}
 
-	// net_id = k3(net_key)
-	if (!mesh_crypto_k3(pvt->net_key, net_id))
+	mesh_io		= SSL_get_ex_data(ssl, 0);
+	silvair_io	= SSL_get_ex_data(ssl, 1);
+
+	conn = l_queue_find(mesh_io->pvt->conns,
+			    match_tcpserver_conn_by_identity, identity_buf);
+	if (!conn) {
+		l_warn("Could not find PSK for identity: '%s'", identity);
 		return 0;
+	}
 
-	// s1_info = (uuid|net_id)
-	memcpy(s1_info, pvt->uuid, UUID_LEN);
-	memcpy(s1_info + UUID_LEN, net_id, sizeof(net_id));
+	conn->io = silvair_io;
 
-	// id = s1(s1_info)
-	if (!mesh_crypto_s1(s1_info, sizeof(s1_info), id))
-		return 0;
+	if (conn->conn_stat)
+		conn_stat_connected_set(conn->conn_stat, true);
 
-	id_str = l_util_hexstring_upper(id, sizeof(id));
-
-	// compare str format 'identity' and 'id_str'
-	if (!strcmp(identity, id_str))
-		goto done;
-
-	// psk = k1(dev_key, id, "idpsk")
-	if (!mesh_crypto_k1(pvt->dev_key, id, k1_info, sizeof(k1_info), psk))
-		goto done;
-
-	// psk is constant length
-	psk_len = 16;
-
-done:
-	l_free(id_str);
-	return psk_len;
+	return tcpserver_acl_psk_get(
+		mesh_io->pvt->acl, identity, psk, max_psk_len);
 }
 
 static bool tls_ctx_init(struct mesh_io_private *pvt)
@@ -387,37 +431,36 @@ static bool tls_ctx_init(struct mesh_io_private *pvt)
 	return true;
 }
 
-static bool process_tls_args(char *argv[],
-				size_t argc, struct mesh_io_private *pvt)
+static bool acl_entry_changed(struct tcpserver_acl *acl,
+			      uint8_t *identity, void *user_data, bool removed)
 {
-	size_t len;
+	struct mesh_io		*mesh_io = user_data;
+	struct tcpserver_conn	*conn;
 
-	pvt->uuid = l_util_from_hexstring(argv[1], &len);
+	if (removed) {
+		conn = l_queue_find(mesh_io->pvt->conns,
+				    match_tcpserver_conn_by_identity, identity);
+		if (!conn)
+			return false;
 
-	if (!pvt->uuid || len != UUID_LEN) {
-		l_error("Invalid UUID length");
-		return false;
+		tcpserver_conn_destroy(conn);
+
+		return l_queue_remove(mesh_io->pvt->conns, conn);
 	}
 
-	pvt->dev_key = l_util_from_hexstring(argv[2], &len);
+	conn = tcpserver_conn_new(identity);
 
-	if (!pvt->dev_key || len != DEV_KEY_LEN) {
-		l_error("Invalid 'dev-key' length");
+	if (!l_queue_push_tail(mesh_io->pvt->conns, conn))
 		return false;
-	}
 
-	pvt->net_key = l_util_from_hexstring(argv[3], &len);
-
-	if (!pvt->net_key || len != NET_KEY_LEN) {
-		l_error("Invalid 'net-key' length");
-		return false;
-	}
+	if (mesh_io->pvt->dbus)
+		create_conn_stat(conn, mesh_io);
 
 	return true;
 }
 
 static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
-				mesh_io_ready_func_t cb, void *user_data)
+			      mesh_io_ready_func_t cb, void *user_data)
 {
 	/* Listening socket descriptor */
 	int server_fd;
@@ -461,17 +504,8 @@ static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
 		return false;
 	}
 
-	// Required TLS arguments: <UUID>,<dev_key>,<net_key>
-	if (argc == 4) {
-		if (!process_tls_args(argv, argc, mesh_io->pvt))
-			return false;
-
-		if (!tls_ctx_init(mesh_io->pvt))
-			return false;
-	} else {
-		l_error("Invalid number of arguments.");
+	if (!tls_ctx_init(mesh_io->pvt))
 		return false;
-	}
 
 	/* Get the listener */
 	server_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -482,14 +516,14 @@ static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
 	}
 
 	if (fcntl(server_fd, F_SETFL,
-		fcntl(server_fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
+		  fcntl(server_fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
 
 		l_error("fcntl() error");
 		return false;
 	}
 
 	if (setsockopt(server_fd, SOL_SOCKET,
-				SO_REUSEADDR, &(int){ 1 }, sizeof(int)) < 0) {
+		       SO_REUSEADDR, &(int){ 1 }, sizeof(int)) < 0) {
 
 		l_error("setsockopt() error");
 		return false;
@@ -501,7 +535,7 @@ static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
 	serveraddr.sin_family = AF_INET;
 
 	if (bind(server_fd, (struct sockaddr *)&serveraddr,
-						sizeof(serveraddr)) < 0) {
+		 sizeof(serveraddr)) < 0) {
 
 		l_error("Failed to start mesh io (bind): %s", strerror(errno));
 		return false;
@@ -511,12 +545,12 @@ static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
 
 	if (listen(server_fd, 1) < 0) {
 		l_error("Failed to start mesh io (listen): %s",
-							strerror(errno));
+			strerror(errno));
 		return false;
 	}
 
 	mesh_io->pvt->server_io = l_io_new(server_fd);
-	mesh_io->pvt->client_io = l_queue_new();
+	mesh_io->pvt->conns	= l_queue_new();
 	mesh_io->pvt->rx_regs = l_queue_new();
 	mesh_io->pvt->tx_pkts = l_queue_new();
 
@@ -524,15 +558,21 @@ static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
 	mesh_io->pvt->user_data = user_data;
 
 	if (!l_io_set_read_handler(mesh_io->pvt->server_io,
-					io_accept_callback, mesh_io, NULL)) {
+				   io_accept_callback, mesh_io, NULL)) {
 		l_error("l_io_set_read_handler error");
 		return false;
 	}
 
 	mesh_io->pvt->tx_timeout = l_timeout_create_ms(0, send_timeout,
-								mesh_io, NULL);
+						       mesh_io, NULL);
 
-	l_info("Started mesh on tcp port %d", port);
+	mesh_io->pvt->dbus_path = l_strdup_printf("%s/tcpserver_%hu",
+						  BLUEZ_MESH_PATH, port);
+
+	mesh_io->pvt->acl = tcpserver_acl_new(mesh_get_storage_dir(),
+			mesh_io->pvt->dbus_path, acl_entry_changed, mesh_io);
+
+	l_info("Started mesh on tcp port %hu", port);
 	l_idle_oneshot(tcpserver_io_init_done, mesh_io, NULL);
 	return true;
 }
@@ -546,21 +586,19 @@ static bool tcpserver_io_destroy(struct mesh_io *mesh_io)
 
 	l_io_destroy(pvt->server_io);
 
-	if (pvt->client_io != NULL) {
-		struct l_queue *queue = pvt->client_io;
+	if (pvt->conns) {
+		struct l_queue *queue = pvt->conns;
 
-		pvt->client_io = NULL;
+		pvt->conns = NULL;
 		l_queue_destroy(queue,
-				(l_queue_destroy_func_t) silvair_io_destroy);
+				(l_queue_destroy_func_t)tcpserver_conn_destroy);
 	}
 
 	l_queue_destroy(pvt->rx_regs, l_free);
 	l_queue_destroy(pvt->tx_pkts, l_free);
 	l_timeout_remove(pvt->tx_timeout);
 
-	l_free(pvt->uuid);
-	l_free(pvt->dev_key);
-	l_free(pvt->net_key);
+	tcpserver_acl_destroy(pvt->acl);
 
 	l_free(pvt);
 	mesh_io->pvt = NULL;
@@ -568,7 +606,7 @@ static bool tcpserver_io_destroy(struct mesh_io *mesh_io)
 }
 
 static bool tcpserver_io_caps(struct mesh_io *mesh_io,
-			struct mesh_io_caps *caps)
+			      struct mesh_io_caps *caps)
 {
 	struct mesh_io_private *pvt = mesh_io->pvt;
 
@@ -582,15 +620,21 @@ static bool tcpserver_io_caps(struct mesh_io *mesh_io,
 
 static void send_flush_all_clients(void *data, void *user_data)
 {
-	struct silvair_io *silvair_io = data;
-	struct tx_pkt *tx = user_data;
+	struct tcpserver_conn	*conn = data;
+	struct tx_pkt		*tx = user_data;
 
-	silvair_io_send_message(silvair_io, tx->data, tx->len);
+	if (!conn->io)
+		return;
+
+	silvair_io_send_message(conn->io, tx->data, tx->len);
+
+	if (conn->conn_stat)
+		conn_stat_message_sent(conn->conn_stat);
 }
 
 static void send_flush(struct mesh_io *mesh_io)
 {	struct tx_pkt *tx;
-	struct l_queue *client_queue = mesh_io->pvt->client_io;
+	struct l_queue *client_queue = mesh_io->pvt->conns;
 	uint32_t instant = get_instant();
 
 	do {
@@ -606,7 +650,7 @@ static void send_flush(struct mesh_io *mesh_io)
 
 	if (tx)
 		l_timeout_modify_ms(mesh_io->pvt->tx_timeout,
-							tx->instant - instant);
+				    tx->instant - instant);
 }
 
 static void send_timeout(struct l_timeout *timeout, void *user_data)
@@ -620,7 +664,7 @@ static void send_timeout(struct l_timeout *timeout, void *user_data)
 }
 
 static int compare_tx_pkt_instant(const void *a, const void *b,
-							void *user_data)
+				  void *user_data)
 {
 	const struct tx_pkt *lhs = a;
 	const struct tx_pkt *rhs = b;
@@ -632,7 +676,7 @@ static int compare_tx_pkt_instant(const void *a, const void *b,
 }
 
 static void send_pkt(struct mesh_io *mesh_io,
-			const uint8_t *data, uint16_t len, uint32_t instant)
+		     const uint8_t *data, uint16_t len, uint32_t instant)
 {
 	struct tx_pkt *tx = l_new(struct tx_pkt, 1);
 
@@ -645,7 +689,8 @@ static void send_pkt(struct mesh_io *mesh_io,
 }
 
 static bool tcpserver_io_send(struct mesh_io *mesh_io,
-	struct mesh_io_send_info *info, const uint8_t *data, uint16_t len)
+			      struct mesh_io_send_info *info,
+			      const uint8_t *data, uint16_t len)
 {
 	uint32_t instant;
 	uint16_t interval;
@@ -675,7 +720,7 @@ static bool tcpserver_io_send(struct mesh_io *mesh_io,
 
 		for (i = 0; i < info->u.gen.cnt; ++i)
 			send_pkt(mesh_io, data, len,
-					instant + delay + interval * i);
+				 instant + delay + interval * i);
 		break;
 
 	case MESH_IO_TIMING_TYPE_POLL:
@@ -761,7 +806,7 @@ static bool find_by_pattern(const void *a, const void *b)
 }
 
 static bool tcpserver_io_cancel(struct mesh_io *mesh_io,
-			const uint8_t *data, uint8_t len)
+				const uint8_t *data, uint8_t len)
 {
 	struct mesh_io_private *pvt = mesh_io->pvt;
 	struct tx_pkt *tx;
@@ -775,7 +820,7 @@ static bool tcpserver_io_cancel(struct mesh_io *mesh_io,
 
 	do {
 		tx = l_queue_remove_if(pvt->tx_pkts, find_by_pattern,
-							&pattern);
+				       &pattern);
 		l_free(tx);
 	} while (tx);
 
@@ -783,10 +828,40 @@ static bool tcpserver_io_cancel(struct mesh_io *mesh_io,
 
 	if (tx)
 		l_timeout_modify_ms(pvt->tx_timeout,
-						tx->instant - get_instant());
+				    tx->instant - get_instant());
 
 	return true;
 }
+
+static void create_conn_stat(void *data, void *user_data)
+{
+	char name[2 * IDENTITY_LEN + 1];
+
+	struct tcpserver_conn	*conn = data;
+	struct mesh_io		*mesh_io = user_data;
+
+	if (!hex2str(conn->identity, IDENTITY_LEN, name, sizeof(name)))
+		return;
+
+	conn->conn_stat = conn_stat_new(mesh_io->pvt->dbus,
+					mesh_io->pvt->dbus_path, name);
+}
+
+static bool tcpserver_io_dbus_init(struct mesh_io *mesh_io, struct l_dbus *dbus)
+{
+	if (!tcpserver_acl_dbus_init(mesh_io->pvt->acl, dbus))
+		return false;
+
+	if (!conn_stat_dbus_init(dbus))
+		return false;
+
+	mesh_io->pvt->dbus = dbus;
+
+	l_queue_foreach(mesh_io->pvt->conns, create_conn_stat, mesh_io);
+
+	return true;
+}
+
 
 const struct mesh_io_api mesh_io_tcpserver = {
 	.init = tcpserver_io_init,
@@ -796,4 +871,5 @@ const struct mesh_io_api mesh_io_tcpserver = {
 	.reg = tcpserver_io_reg,
 	.dereg = tcpserver_io_dereg,
 	.cancel = tcpserver_io_cancel,
+	.dbus_init = tcpserver_io_dbus_init,
 };

--- a/mesh/mesh-io-tcpserver.c
+++ b/mesh/mesh-io-tcpserver.c
@@ -1,0 +1,799 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <termios.h>
+#include <arpa/inet.h>
+#include <linux/tty.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/limits.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <ell/ell.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/bio.h>
+
+#include "src/shared/io.h"
+
+#include "mesh/crypto.h"
+#include "mesh/mesh-io.h"
+#include "mesh/mesh-io-api.h"
+#include "mesh/mesh-io-tcpserver.h"
+#include "mesh/silvair-io.h"
+
+
+#define UUID_LEN		(16)
+#define DEV_KEY_LEN		(16)
+#define NET_KEY_LEN		(16)
+
+static const char *tls_ciphers = "ECDHE-PSK-CHACHA20-POLY1305";
+
+struct mesh_io_private {
+
+	void *user_data;
+	mesh_io_ready_func_t ready_callback;
+
+	struct l_io		*server_io;
+	struct l_queue		*client_io;
+
+	struct l_timeout	*tx_timeout;
+	struct l_queue		*rx_regs;
+	struct l_queue		*tx_pkts;
+
+	/* Simple filtering on AD type only */
+	uint8_t				filters[4];
+	struct tx_pkt		*tx;
+
+	/* TLS context */
+	SSL_CTX				*tls_ctx;
+
+	uint8_t				*uuid;
+	uint8_t				*dev_key;
+	uint8_t				*net_key;
+};
+
+
+struct pvt_rx_reg {
+	mesh_io_recv_func_t cb;
+	void *user_data;
+	uint8_t len;
+	uint8_t filter[0];
+};
+
+struct process_data {
+	struct mesh_io_private		*pvt;
+	const uint8_t			*data;
+	uint8_t				len;
+	struct mesh_io_recv_info	info;
+};
+
+struct tx_pkt {
+	uint32_t	instant;
+	uint8_t		len;
+	uint8_t		data[30];
+};
+
+struct tx_pattern {
+	const uint8_t			*data;
+	uint8_t				len;
+};
+
+enum io_type {
+	IO_TYPE_SERVER,
+	IO_TYPE_CLIENT
+};
+
+static void send_timeout(struct l_timeout *timeout, void *user_data);
+
+
+static uint32_t get_instant(void)
+{
+	struct timeval tm;
+	uint32_t instant;
+
+	gettimeofday(&tm, NULL);
+	instant = tm.tv_sec * 1000;
+	instant += tm.tv_usec / 1000;
+
+	return instant;
+}
+
+static void process_rx_callbacks(void *v_rx, void *v_reg)
+{
+	struct pvt_rx_reg *rx_reg = v_rx;
+	struct process_data *rx = v_reg;
+
+	if (!memcmp(rx->data, rx_reg->filter, rx_reg->len))
+		rx_reg->cb(rx_reg->user_data, &rx->info, rx->data, rx->len);
+}
+
+static void process_rx(struct silvair_io *silvair_io, int8_t rssi,
+			const uint8_t *data, uint8_t len, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+	struct process_data rx;
+
+	if (!mesh_io) {
+		l_error("mesh_io does not exist");
+		return;
+	}
+
+	rx.pvt = mesh_io->pvt,
+	rx.data = data,
+	rx.len = len,
+	rx.info.instant = get_instant(),
+	rx.info.chan = 7,
+	rx.info.rssi = rssi,
+
+	silvair_io_keep_alive_wdt_refresh(silvair_io);
+	l_queue_foreach(mesh_io->pvt->rx_regs, process_rx_callbacks, &rx);
+}
+
+static bool get_fd_info(int fd, char *log, enum io_type type)
+{
+	/* Address */
+	struct sockaddr_in addr;
+	unsigned int addrlen;
+
+	addrlen = sizeof(addr);
+
+	switch (type) {
+	case IO_TYPE_CLIENT:
+		if (getpeername(fd, (struct sockaddr *)&addr, &addrlen) < 0) {
+			l_error("getpeername() error");
+			return false;
+		}
+		break;
+
+	case IO_TYPE_SERVER:
+		if (getsockname(fd, (struct sockaddr *)&addr, &addrlen) < 0) {
+			l_error("getsockname() error");
+			return false;
+		}
+		break;
+
+	default:
+		l_error("get_df_info() Invalid type");
+		return false;
+	}
+
+	l_info("%s -> addr:%s port:%d fd:%d", log,
+			inet_ntoa(addr.sin_addr), ntohs(addr.sin_port), fd);
+	return true;
+}
+
+static void io_error_callback(struct silvair_io *silvair_io)
+{
+	int fd = silvair_io_get_fd(silvair_io);
+
+	if (fd > 0) {
+		get_fd_info(fd, "Disconnecting the TCP client", IO_TYPE_CLIENT);
+
+		/* shutdown will trigger the io_disconnect_callback() */
+		shutdown(fd, SHUT_RDWR);
+	}
+}
+
+static void io_disconnect_callback(struct silvair_io *silvair_io)
+{
+	struct mesh_io *mesh_io = silvair_io->context;
+
+	if (!mesh_io->pvt->client_io)
+		return;
+
+	if (!l_queue_remove(mesh_io->pvt->client_io, silvair_io)) {
+		perror("l_queue_remove() error");
+		abort();
+	}
+
+	l_info("Client disconneted from TCP Server");
+	silvair_io_destroy(silvair_io);
+}
+
+static bool io_accept_callback(struct l_io *l_io, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+	struct silvair_io *silvair_io = NULL;
+
+	/* Client address */
+	struct sockaddr_in clientaddr;
+	unsigned int client_addrlen;
+
+	/* Newly accepted socket descriptor */
+	int newfd;
+
+	/* Listening socket descriptor */
+	int server_fd;
+
+	SSL *tls_conn = NULL;
+	BIO *sbio = NULL;
+
+	server_fd = l_io_get_fd(l_io);
+
+	if (server_fd < 0) {
+		l_error("l_io_get_fd error");
+		return false;
+	}
+
+	/* Handle new connections */
+	client_addrlen = sizeof(clientaddr);
+
+	newfd = accept(server_fd, (struct sockaddr *)&clientaddr,
+							&client_addrlen);
+
+	if (newfd < 0) {
+		l_error("server accept error");
+		return false;
+	}
+
+
+	if (fcntl(newfd, F_SETFL,
+			fcntl(newfd, F_GETFL, 0) | O_NONBLOCK) != 0) {
+		l_error("client fcntl error");
+		return false;
+	}
+
+	// TLS Connection
+	tls_conn = SSL_new(mesh_io->pvt->tls_ctx);
+	if (!tls_conn) {
+		l_error("Failed to create SSL object.");
+		goto error;
+	}
+
+	sbio = BIO_new_socket(newfd, BIO_NOCLOSE);
+	if (!sbio) {
+		l_error("Failed to create BIO object.");
+		goto error;
+	}
+
+	SSL_set_ex_data(tls_conn, 0, mesh_io->pvt);
+	SSL_set_bio(tls_conn, sbio, sbio);
+	SSL_set_accept_state(tls_conn);
+
+	get_fd_info(newfd, "New client accepted", IO_TYPE_CLIENT);
+
+	silvair_io = silvair_io_new(newfd, false, process_rx, io_error_callback,
+		io_disconnect_callback, mesh_io, tls_conn);
+
+	if (!silvair_io) {
+		l_error("silvair_io_new error");
+		goto error;
+	}
+
+	l_io_set_close_on_destroy(silvair_io->l_io, true);
+
+	l_queue_push_tail(mesh_io->pvt->client_io, silvair_io);
+
+	l_info("Connected %s:%hu",
+			inet_ntoa(clientaddr.sin_addr),
+			ntohs(clientaddr.sin_port));
+
+	return true;
+
+error:
+	free(silvair_io);
+	BIO_free(sbio);
+	SSL_free(tls_conn);
+
+	return false;
+}
+
+static void tcpserver_io_init_done(void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+
+	mesh_io->pvt->ready_callback(mesh_io->pvt->user_data, true);
+}
+
+static unsigned int tls_psk_server_cb(SSL *ssl, const char *identity,
+	unsigned char *psk, unsigned int max_psk_len)
+{
+	const char k1_info[] = { 'i', 'd', 'p', 's', 'k' };
+	unsigned int psk_len = 0;
+
+	struct mesh_io_private *pvt;
+	uint8_t net_id[8];
+	char s1_info[24];
+	uint8_t id[16];
+	char *id_str;
+
+	pvt = SSL_get_ex_data(ssl, 0);
+
+	if (!pvt)
+		return 0;
+
+	// net_id = k3(net_key)
+	if (!mesh_crypto_k3(pvt->net_key, net_id))
+		return 0;
+
+	// s1_info = (uuid|net_id)
+	memcpy(s1_info, pvt->uuid, UUID_LEN);
+	memcpy(s1_info + UUID_LEN, net_id, sizeof(net_id));
+
+	// id = s1(s1_info)
+	if (!mesh_crypto_s1(s1_info, sizeof(s1_info), id))
+		return 0;
+
+	id_str = l_util_hexstring_upper(id, sizeof(id));
+
+	// compare str format 'identity' and 'id_str'
+	if (!strcmp(identity, id_str))
+		goto done;
+
+	// psk = k1(dev_key, id, "idpsk")
+	if (!mesh_crypto_k1(pvt->dev_key, id, k1_info, sizeof(k1_info), psk))
+		goto done;
+
+	// psk is constant length
+	psk_len = 16;
+
+done:
+	l_free(id_str);
+	return psk_len;
+}
+
+static bool tls_ctx_init(struct mesh_io_private *pvt)
+{
+	int off = SSL_OP_NO_TLSv1_3 |
+				SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION;
+
+	ERR_load_crypto_strings();
+
+	SSL_library_init();
+
+	pvt->tls_ctx = SSL_CTX_new(TLS_server_method());
+	if (!pvt->tls_ctx) {
+		l_error("Failed to alloc TLS context object.");
+		return false;
+	}
+
+	SSL_CTX_set_quiet_shutdown(pvt->tls_ctx, 0);
+	SSL_CTX_set_options(pvt->tls_ctx, off);
+	SSL_CTX_set_psk_server_callback(pvt->tls_ctx, tls_psk_server_cb);
+
+	if (!SSL_CTX_set_cipher_list(pvt->tls_ctx, tls_ciphers)) {
+		l_error("Failed to set cipher list: '%s'", tls_ciphers);
+		return false;
+	}
+
+	l_info("TLS initialization: done");
+	return true;
+}
+
+static bool process_tls_args(char *argv[],
+				size_t argc, struct mesh_io_private *pvt)
+{
+	size_t len;
+
+	pvt->uuid = l_util_from_hexstring(argv[1], &len);
+
+	if (!pvt->uuid || len != UUID_LEN) {
+		l_error("Invalid UUID length");
+		return false;
+	}
+
+	pvt->dev_key = l_util_from_hexstring(argv[2], &len);
+
+	if (!pvt->dev_key || len != DEV_KEY_LEN) {
+		l_error("Invalid 'dev-key' length");
+		return false;
+	}
+
+	pvt->net_key = l_util_from_hexstring(argv[3], &len);
+
+	if (!pvt->net_key || len != NET_KEY_LEN) {
+		l_error("Invalid 'net-key' length");
+		return false;
+	}
+
+	return true;
+}
+
+static bool tcpserver_io_init(struct mesh_io *mesh_io, void *opts,
+				mesh_io_ready_func_t cb, void *user_data)
+{
+	/* Listening socket descriptor */
+	int server_fd;
+	uint16_t port = 0;
+
+	/* Server address */
+	struct sockaddr_in serveraddr;
+
+	char *opt = opts;
+	char *delim;
+
+	char *argv[4] = { 0 };
+	size_t argc = 0;
+
+	if (!mesh_io)
+		return false;
+
+	mesh_io->pvt = l_new(struct mesh_io_private, 1);
+
+	do {
+		delim = strchr(opt, ',');
+
+		if (delim)
+			*delim = '\0';
+
+		argv[argc++] = opt;
+
+		if (delim)
+			opt = delim + 1;
+
+	} while (delim && (argc < L_ARRAY_SIZE(argv)));
+
+	if (argc > 0) {
+		if (sscanf(argv[0], "%hu", &port) != 1)
+			return false;
+
+		if (!port)
+			return false;
+	} else {
+		l_error("Invalid number of arguments.");
+		return false;
+	}
+
+	// Required TLS arguments: <UUID>,<dev_key>,<net_key>
+	if (argc == 4) {
+		if (!process_tls_args(argv, argc, mesh_io->pvt))
+			return false;
+
+		if (!tls_ctx_init(mesh_io->pvt))
+			return false;
+	} else {
+		l_error("Invalid number of arguments.");
+		return false;
+	}
+
+	/* Get the listener */
+	server_fd = socket(AF_INET, SOCK_STREAM, 0);
+
+	if (server_fd < 0) {
+		l_error("socket() error");
+		return false;
+	}
+
+	if (fcntl(server_fd, F_SETFL,
+		fcntl(server_fd, F_GETFL, 0) | O_NONBLOCK) != 0) {
+
+		l_error("fcntl() error");
+		return false;
+	}
+
+	if (setsockopt(server_fd, SOL_SOCKET,
+				SO_REUSEADDR, &(int){ 1 }, sizeof(int)) < 0) {
+
+		l_error("setsockopt() error");
+		return false;
+	}
+
+	/* Bind */
+	serveraddr.sin_addr.s_addr = INADDR_ANY;
+	serveraddr.sin_port = htons(port);
+	serveraddr.sin_family = AF_INET;
+
+	if (bind(server_fd, (struct sockaddr *)&serveraddr,
+						sizeof(serveraddr)) < 0) {
+
+		l_error("Failed to start mesh io (bind): %s", strerror(errno));
+		return false;
+	}
+
+	get_fd_info(server_fd, "Server bind", IO_TYPE_SERVER);
+
+	if (listen(server_fd, 1) < 0) {
+		l_error("Failed to start mesh io (listen): %s",
+							strerror(errno));
+		return false;
+	}
+
+	mesh_io->pvt->server_io = l_io_new(server_fd);
+	mesh_io->pvt->client_io = l_queue_new();
+	mesh_io->pvt->rx_regs = l_queue_new();
+	mesh_io->pvt->tx_pkts = l_queue_new();
+
+	mesh_io->pvt->ready_callback = cb;
+	mesh_io->pvt->user_data = user_data;
+
+	if (!l_io_set_read_handler(mesh_io->pvt->server_io,
+					io_accept_callback, mesh_io, NULL)) {
+		l_error("l_io_set_read_handler error");
+		return false;
+	}
+
+	mesh_io->pvt->tx_timeout = l_timeout_create_ms(0, send_timeout,
+								mesh_io, NULL);
+
+	l_info("Started mesh on tcp port %d", port);
+	l_idle_oneshot(tcpserver_io_init_done, mesh_io, NULL);
+	return true;
+}
+
+static bool tcpserver_io_destroy(struct mesh_io *mesh_io)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+
+	if (!pvt)
+		return true;
+
+	l_io_destroy(pvt->server_io);
+
+	if (pvt->client_io != NULL) {
+		struct l_queue *queue = pvt->client_io;
+
+		pvt->client_io = NULL;
+		l_queue_destroy(queue,
+				(l_queue_destroy_func_t) silvair_io_destroy);
+	}
+
+	l_queue_destroy(pvt->rx_regs, l_free);
+	l_queue_destroy(pvt->tx_pkts, l_free);
+	l_timeout_remove(pvt->tx_timeout);
+
+	l_free(pvt->uuid);
+	l_free(pvt->dev_key);
+	l_free(pvt->net_key);
+
+	l_free(pvt);
+	mesh_io->pvt = NULL;
+	return true;
+}
+
+static bool tcpserver_io_caps(struct mesh_io *mesh_io,
+			struct mesh_io_caps *caps)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+
+	if (!pvt || !caps)
+		return false;
+
+	caps->max_num_filters = sizeof(pvt->filters);
+	caps->window_accuracy = 50;
+	return true;
+}
+
+static void send_flush_all_clients(void *data, void *user_data)
+{
+	struct silvair_io *silvair_io = data;
+	struct tx_pkt *tx = user_data;
+
+	silvair_io_send_message(silvair_io, tx->data, tx->len);
+}
+
+static void send_flush(struct mesh_io *mesh_io)
+{	struct tx_pkt *tx;
+	struct l_queue *client_queue = mesh_io->pvt->client_io;
+	uint32_t instant = get_instant();
+
+	do {
+		tx = l_queue_peek_head(mesh_io->pvt->tx_pkts);
+
+		if (!tx || tx->instant > instant)
+			break;
+
+		l_queue_foreach(client_queue, send_flush_all_clients, tx);
+		tx = l_queue_pop_head(mesh_io->pvt->tx_pkts);
+		l_free(tx);
+	} while (tx);
+
+	if (tx)
+		l_timeout_modify_ms(mesh_io->pvt->tx_timeout,
+							tx->instant - instant);
+}
+
+static void send_timeout(struct l_timeout *timeout, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+
+	if (!mesh_io)
+		return;
+
+	send_flush(mesh_io);
+}
+
+static int compare_tx_pkt_instant(const void *a, const void *b,
+							void *user_data)
+{
+	const struct tx_pkt *lhs = a;
+	const struct tx_pkt *rhs = b;
+
+	if (lhs->instant == rhs->instant)
+		return 0;
+
+	return lhs->instant < rhs->instant ? -1 : 1;
+}
+
+static void send_pkt(struct mesh_io *mesh_io,
+			const uint8_t *data, uint16_t len, uint32_t instant)
+{
+	struct tx_pkt *tx = l_new(struct tx_pkt, 1);
+
+	tx->instant = instant;
+	tx->len = len;
+	memcpy(tx->data, data, len);
+
+	l_queue_insert(mesh_io->pvt->tx_pkts, tx, compare_tx_pkt_instant, NULL);
+	send_flush(mesh_io);
+}
+
+static bool tcpserver_io_send(struct mesh_io *mesh_io,
+	struct mesh_io_send_info *info, const uint8_t *data, uint16_t len)
+{
+	uint32_t instant;
+	uint16_t interval;
+	uint8_t delay;
+	int i;
+
+	if (!info || !data || !len)
+		return false;
+
+	switch (info->type) {
+
+	case MESH_IO_TIMING_TYPE_GENERAL:
+		instant = get_instant();
+		interval = info->u.gen.interval;
+
+		if (info->u.gen.min_delay == info->u.gen.max_delay)
+			delay = info->u.gen.min_delay;
+		else {
+			l_getrandom(&delay, sizeof(delay));
+			delay %= info->u.gen.max_delay - info->u.gen.min_delay;
+			delay += info->u.gen.min_delay;
+		}
+
+		// FIXME: such packets need to be rescheduled on flush
+		if (info->u.gen.cnt == MESH_IO_TX_COUNT_UNLIMITED)
+			info->u.gen.cnt = 1;
+
+		for (i = 0; i < info->u.gen.cnt; ++i)
+			send_pkt(mesh_io, data, len,
+					instant + delay + interval * i);
+		break;
+
+	case MESH_IO_TIMING_TYPE_POLL:
+		instant = get_instant();
+
+		if (info->u.gen.min_delay == info->u.gen.max_delay)
+			delay = info->u.gen.min_delay;
+		else {
+			l_getrandom(&delay, sizeof(delay));
+			delay %= info->u.gen.max_delay - info->u.gen.min_delay;
+			delay += info->u.gen.min_delay;
+		}
+
+		send_pkt(mesh_io, data, len, instant + delay);
+		break;
+
+	case MESH_IO_TIMING_TYPE_POLL_RSP:
+		instant = info->u.poll_rsp.instant;
+		delay = info->u.poll_rsp.delay;
+
+		send_pkt(mesh_io, data, len, instant + delay);
+		break;
+	}
+
+	return true;
+}
+
+static bool find_by_filter(const void *a, const void *b)
+{
+	const struct pvt_rx_reg *rx_reg = a;
+	const uint8_t *filter = b;
+
+	return !memcmp(rx_reg->filter, filter, rx_reg->len);
+}
+
+static bool tcpserver_io_reg(struct mesh_io *mesh_io, const uint8_t *filter,
+			uint8_t len, mesh_io_recv_func_t cb, void *user_data)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct pvt_rx_reg *rx_reg;
+
+	if (!cb || !filter || !len)
+		return false;
+
+	l_info("%s %2.2x", __func__, filter[0]);
+	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter, filter);
+
+	l_free(rx_reg);
+	rx_reg = l_malloc(sizeof(*rx_reg) + len);
+
+	memcpy(rx_reg->filter, filter, len);
+	rx_reg->len = len;
+	rx_reg->cb = cb;
+	rx_reg->user_data = user_data;
+
+	l_queue_push_head(pvt->rx_regs, rx_reg);
+	return true;
+}
+
+static bool tcpserver_io_dereg(struct mesh_io *mesh_io, const uint8_t *filter,
+								uint8_t len)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct pvt_rx_reg *rx_reg;
+
+	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter, filter);
+
+	if (rx_reg)
+		l_free(rx_reg);
+
+	return true;
+}
+
+static bool find_by_pattern(const void *a, const void *b)
+{
+	const struct tx_pkt *tx = a;
+	const struct tx_pattern *pattern = b;
+
+	if (tx->len < pattern->len)
+		return false;
+
+	return (!memcmp(tx->data, pattern->data, pattern->len));
+}
+
+static bool tcpserver_io_cancel(struct mesh_io *mesh_io,
+			const uint8_t *data, uint8_t len)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct tx_pkt *tx;
+	const struct tx_pattern pattern = {
+		.data = data,
+		.len = len
+	};
+
+	if (!data)
+		return false;
+
+	do {
+		tx = l_queue_remove_if(pvt->tx_pkts, find_by_pattern,
+							&pattern);
+		l_free(tx);
+	} while (tx);
+
+	tx = l_queue_peek_head(pvt->tx_pkts);
+
+	if (tx)
+		l_timeout_modify_ms(pvt->tx_timeout,
+						tx->instant - get_instant());
+
+	return true;
+}
+
+const struct mesh_io_api mesh_io_tcpserver = {
+	.init = tcpserver_io_init,
+	.destroy = tcpserver_io_destroy,
+	.caps = tcpserver_io_caps,
+	.send = tcpserver_io_send,
+	.reg = tcpserver_io_reg,
+	.dereg = tcpserver_io_dereg,
+	.cancel = tcpserver_io_cancel,
+};

--- a/mesh/mesh-io-tcpserver.h
+++ b/mesh/mesh-io-tcpserver.h
@@ -1,0 +1,20 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+
+extern const struct mesh_io_api mesh_io_tcpserver;

--- a/mesh/mesh-io-uart.c
+++ b/mesh/mesh-io-uart.c
@@ -1,0 +1,575 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <arpa/inet.h>
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/limits.h>
+#include <sys/ioctl.h>
+#include <sys/time.h>
+#include <ell/ell.h>
+#include <stdlib.h>
+
+#include "mesh/mesh-io.h"
+#include "mesh/mesh-io-api.h"
+#include "mesh/mesh-io-uart.h"
+#include "mesh/silvair-io.h"
+
+
+struct mesh_io_private {
+	void *user_data;
+	mesh_io_ready_func_t ready_callback;
+
+	char			tty_name[PATH_MAX];
+	int			tty_fd;
+
+	char			iface_name[IFNAMSIZ];
+	int			iface_fd;
+
+	struct silvair_io	*silvair_io;
+	struct l_timeout	*tx_timeout;
+	struct l_queue		*rx_regs;
+	struct l_queue		*tx_pkts;
+
+	/* Simple filtering on AD type only */
+	struct tx_pkt		*tx;
+};
+
+struct pvt_rx_reg {
+	mesh_io_recv_func_t cb;
+	void *user_data;
+	uint8_t len;
+	uint8_t filter[0];
+};
+
+struct process_data {
+	struct mesh_io_private		*pvt;
+	const uint8_t			*data;
+	uint8_t				len;
+	struct mesh_io_recv_info	info;
+};
+
+struct tx_pkt {
+	uint32_t	instant;
+	uint8_t		len;
+	uint8_t		data[30];
+};
+
+struct tx_pattern {
+	const uint8_t	*data;
+	uint8_t		len;
+};
+
+static void send_timeout(struct l_timeout *timeout, void *user_data);
+
+
+static uint32_t get_instant(void)
+{
+	struct timeval tm;
+	uint32_t instant;
+
+	gettimeofday(&tm, NULL);
+	instant = tm.tv_sec * 1000;
+	instant += tm.tv_usec / 1000;
+
+	return instant;
+}
+
+static void process_rx_callbacks(void *v_rx, void *v_reg)
+{
+	struct pvt_rx_reg *rx_reg = v_rx;
+	struct process_data *rx = v_reg;
+
+	if (!memcmp(rx->data, rx_reg->filter, rx_reg->len))
+		rx_reg->cb(rx_reg->user_data, &rx->info, rx->data, rx->len);
+}
+
+static void process_rx(struct silvair_io *silvair_io, int8_t rssi,
+			const uint8_t *data, uint8_t len, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+	struct process_data rx;
+
+	rx.pvt = mesh_io->pvt,
+	rx.data = data,
+	rx.len = len,
+	rx.info.instant = get_instant(),
+	rx.info.chan = 7,
+	rx.info.rssi = rssi,
+
+	silvair_io_keep_alive_wdt_refresh(silvair_io);
+	l_queue_foreach(mesh_io->pvt->rx_regs, process_rx_callbacks, &rx);
+}
+
+static void io_error_callback(struct silvair_io *silvair_io)
+{
+	l_main_quit();
+}
+
+static bool uart_kernel_init(struct mesh_io *mesh_io)
+{
+	struct ifreq req;
+	struct sockaddr_ll addr;
+	int disc = N_SLIP;
+	int encap = 0;
+
+	if (ioctl(mesh_io->pvt->tty_fd, TIOCSETD, &disc) != 0) {
+		l_error("cannot set line discipline: %s", strerror(errno));
+		return false;
+	}
+
+	if (ioctl(mesh_io->pvt->tty_fd, SIOCSIFENCAP, &encap) != 0) {
+		l_error("cannot set encapsulation: %s", strerror(errno));
+		return false;
+	}
+
+	if (ioctl(mesh_io->pvt->tty_fd, SIOCGIFNAME,
+				mesh_io->pvt->iface_name) != 0)
+		return false;
+
+	l_strlcpy(req.ifr_name, mesh_io->pvt->iface_name, sizeof(req.ifr_name));
+
+	mesh_io->pvt->iface_fd = socket(PF_PACKET, SOCK_RAW, 0);
+
+	if (mesh_io->pvt->iface_fd < 0) {
+		l_error("%s: cannot open socket: %s",
+			mesh_io->pvt->iface_name, strerror(errno));
+		return false;
+	}
+
+	if (ioctl(mesh_io->pvt->iface_fd, SIOCGIFINDEX, &req) != 0) {
+		l_error("%s: cannot get interface index: %s",
+			mesh_io->pvt->iface_name, strerror(errno));
+		return false;
+	}
+
+	addr.sll_family = AF_PACKET;
+	addr.sll_protocol = htons(ETH_P_ALL);
+	addr.sll_ifindex = req.ifr_ifindex;
+	addr.sll_pkttype = PACKET_HOST;
+
+	req.ifr_flags |= IFF_UP;
+
+	if (ioctl(mesh_io->pvt->iface_fd, SIOCSIFFLAGS, &req) != 0) {
+		l_error("%s: cannot bring interface up: %s",
+			mesh_io->pvt->iface_name, strerror(errno));
+		return false;
+	}
+
+	if (bind(mesh_io->pvt->iface_fd, (struct sockaddr *)&addr,
+							sizeof(addr)) != 0) {
+		l_error("%s: cannot bind interface: %s",
+			mesh_io->pvt->iface_name, strerror(errno));
+		return false;
+	}
+
+	l_info("Started mesh on tty %s, interface %s", mesh_io->pvt->tty_name,
+		mesh_io->pvt->iface_name);
+
+	mesh_io->pvt->silvair_io = silvair_io_new(mesh_io->pvt->iface_fd,
+						true,
+						process_rx,
+						io_error_callback,
+						NULL,
+						mesh_io,
+						NULL);
+	return true;
+}
+
+static bool uart_user_init(struct mesh_io *mesh_io)
+{
+	mesh_io->pvt->silvair_io = silvair_io_new(mesh_io->pvt->tty_fd,
+						false,
+						process_rx,
+						io_error_callback,
+						NULL,
+						mesh_io,
+						NULL);
+	mesh_io->pvt->iface_fd = -1;
+
+	l_info("Started mesh on tty %s", mesh_io->pvt->tty_name);
+	return true;
+}
+
+static bool uart_tty_init(struct mesh_io *mesh_io, bool flow)
+{
+	struct termios ttys = { .c_cflag = CREAD, 0};
+
+	mesh_io->pvt->tty_fd = open(mesh_io->pvt->tty_name, O_RDWR);
+
+	if (mesh_io->pvt->tty_fd < 0) {
+		l_error("%s: cannot open: %s", mesh_io->pvt->tty_name,
+							strerror(errno));
+		return false;
+	}
+
+	cfmakeraw(&ttys);
+
+	cfsetspeed(&ttys, B1000000);
+
+	if (flow)
+		ttys.c_cflag |= CRTSCTS;
+	else
+		ttys.c_cflag &= ~CRTSCTS;
+
+	if (tcsetattr(mesh_io->pvt->tty_fd, TCSANOW, &ttys) != 0) {
+		l_error("%s: cannot configure tty: %s",
+			mesh_io->pvt->tty_name, strerror(errno));
+		return false;
+	}
+
+	return true;
+}
+
+static void uart_io_init_done(void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+
+	mesh_io->pvt->ready_callback(mesh_io->pvt->user_data, true);
+}
+
+static bool uart_io_init(struct mesh_io *mesh_io, void *opts,
+				mesh_io_ready_func_t cb, void *user_data)
+{
+	bool tty_kernel = false;
+	bool tty_flow = false;
+
+	char *opts_delim = strchr(opts, ':');
+	char *opt;
+	char *delim;
+
+	if (opts_delim) {
+		*opts_delim = '\0';
+		opt = opts_delim + 1;
+
+		if (!*opt) {
+			l_error("missing options");
+			return false;
+		}
+
+		do {
+			delim = strchr(opt, ',');
+
+			if (delim)
+				*delim = '\0';
+
+			if (!strcmp(opt, "kernel"))
+				tty_kernel = true;
+
+			if (!strcmp(opt, "nokernel"))
+				tty_kernel = false;
+
+			if (!strcmp(opt, "flow"))
+				tty_flow = true;
+
+			if (!strcmp(opt, "noflow"))
+				tty_flow = false;
+
+			opt = delim + 1;
+
+		} while (delim);
+	}
+
+	if (!mesh_io || mesh_io->pvt)
+		return false;
+
+	mesh_io->pvt = l_new(struct mesh_io_private, 1);
+
+	strncpy(mesh_io->pvt->tty_name, opts,
+		sizeof(mesh_io->pvt->tty_name) - 1);
+
+	l_debug("%s: flow control %s, slip in %s",
+		mesh_io->pvt->tty_name, tty_flow ? "on" : "off",
+		tty_kernel ? "kernel" : "userspace");
+
+	if (!uart_tty_init(mesh_io, tty_flow)) {
+		l_error("tty initialization failed");
+		return false;
+	}
+
+	if (!(tty_kernel ? uart_kernel_init : uart_user_init)(mesh_io)) {
+		l_error("initialization failed");
+		return false;
+	}
+
+	mesh_io->pvt->rx_regs = l_queue_new();
+	mesh_io->pvt->tx_pkts = l_queue_new();
+
+	mesh_io->pvt->ready_callback = cb;
+	mesh_io->pvt->user_data = user_data;
+
+	mesh_io->pvt->tx_timeout = l_timeout_create_ms(0, send_timeout,
+					mesh_io, NULL);
+
+	l_idle_oneshot(uart_io_init_done, mesh_io, NULL);
+	return true;
+}
+
+static bool uart_io_destroy(struct mesh_io *mesh_io)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct silvair_io *silvair_io = mesh_io->pvt->silvair_io;
+
+	if (!pvt)
+		return true;
+
+	if (silvair_io)
+		silvair_io_destroy(silvair_io);
+
+	close(pvt->iface_fd);
+	close(pvt->tty_fd);
+	l_timeout_remove(pvt->tx_timeout);
+	l_queue_destroy(pvt->rx_regs, l_free);
+	l_queue_destroy(pvt->tx_pkts, l_free);
+	l_free(pvt);
+
+	return true;
+}
+
+static bool uart_io_caps(struct mesh_io *mesh_io, struct mesh_io_caps *caps)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+
+	if (!pvt || !caps)
+		return false;
+
+	caps->max_num_filters = 255;
+	caps->window_accuracy = 50;
+
+	return true;
+}
+
+static void send_flush(struct mesh_io *mesh_io)
+{
+	struct tx_pkt *tx;
+	uint32_t instant = get_instant();
+	struct silvair_io *silvair_io = mesh_io->pvt->silvair_io;
+
+	do {
+		tx = l_queue_peek_head(mesh_io->pvt->tx_pkts);
+
+		if (!tx || tx->instant > instant)
+			break;
+
+		silvair_io_send_message(silvair_io, tx->data, tx->len);
+		tx = l_queue_pop_head(mesh_io->pvt->tx_pkts);
+		l_free(tx);
+
+	} while (tx);
+
+	if (tx)
+		l_timeout_modify_ms(mesh_io->pvt->tx_timeout,
+						tx->instant - instant);
+}
+
+static void send_timeout(struct l_timeout *timeout, void *user_data)
+{
+	struct mesh_io *mesh_io = user_data;
+
+	if (!mesh_io)
+		return;
+
+	send_flush(mesh_io);
+}
+
+static int compare_tx_pkt_instant(const void *a, const void *b, void *user_data)
+{
+	const struct tx_pkt *lhs = a;
+	const struct tx_pkt *rhs = b;
+	(void)user_data;
+
+	if (lhs->instant == rhs->instant)
+		return 0;
+
+	return lhs->instant < rhs->instant ? -1 : 1;
+}
+
+static void send_pkt(struct mesh_io *mesh_io,
+			const uint8_t *data, uint16_t len, uint32_t instant)
+{
+	struct tx_pkt *tx = l_new(struct tx_pkt, 1);
+
+	tx->instant = instant;
+	tx->len = len;
+	memcpy(tx->data, data, len);
+
+	l_queue_insert(mesh_io->pvt->tx_pkts, tx, compare_tx_pkt_instant, NULL);
+	send_flush(mesh_io);
+}
+
+static bool uart_io_send(struct mesh_io *mesh_io,
+			struct mesh_io_send_info *info,
+			const uint8_t *data, uint16_t len)
+{
+	uint32_t instant;
+	uint16_t interval;
+	uint8_t delay;
+	int i;
+
+	if (!info || !data || !len)
+		return false;
+
+	switch (info->type) {
+
+	case MESH_IO_TIMING_TYPE_GENERAL:
+		instant = get_instant();
+		interval = info->u.gen.interval;
+
+		if (info->u.gen.min_delay == info->u.gen.max_delay)
+			delay = info->u.gen.min_delay;
+		else {
+			l_getrandom(&delay, sizeof(delay));
+			delay %= info->u.gen.max_delay - info->u.gen.min_delay;
+			delay += info->u.gen.min_delay;
+		}
+
+		// FIXME: such packets need to be rescheduled on flush
+		if (info->u.gen.cnt == MESH_IO_TX_COUNT_UNLIMITED)
+			info->u.gen.cnt = 1;
+
+		for (i = 0; i < info->u.gen.cnt; ++i)
+			send_pkt(mesh_io, data, len,
+					instant + delay + interval * i);
+		break;
+
+	case MESH_IO_TIMING_TYPE_POLL:
+		instant = get_instant();
+
+		if (info->u.gen.min_delay == info->u.gen.max_delay)
+			delay = info->u.gen.min_delay;
+		else {
+			l_getrandom(&delay, sizeof(delay));
+			delay %= info->u.gen.max_delay - info->u.gen.min_delay;
+			delay += info->u.gen.min_delay;
+		}
+
+		send_pkt(mesh_io, data, len, instant + delay);
+		break;
+
+	case MESH_IO_TIMING_TYPE_POLL_RSP:
+		instant = info->u.poll_rsp.instant;
+		delay = info->u.poll_rsp.delay;
+
+		send_pkt(mesh_io, data, len, instant + delay);
+		break;
+	}
+
+	return true;
+}
+
+static bool find_by_filter(const void *a, const void *b)
+{
+	const struct pvt_rx_reg *rx_reg = a;
+	const uint8_t *filter = b;
+
+	return !memcmp(rx_reg->filter, filter, rx_reg->len);
+}
+
+static bool uart_io_reg(struct mesh_io *mesh_io, const uint8_t *filter,
+			uint8_t len, mesh_io_recv_func_t cb, void *user_data)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct pvt_rx_reg *rx_reg;
+
+	if (!cb || !filter || !len)
+		return false;
+
+	l_info("%s %2.2x", __func__, filter[0]);
+	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter, filter);
+
+	l_free(rx_reg);
+	rx_reg = l_malloc(sizeof(*rx_reg) + len);
+
+	memcpy(rx_reg->filter, filter, len);
+	rx_reg->len = len;
+	rx_reg->cb = cb;
+	rx_reg->user_data = user_data;
+
+	l_queue_push_head(pvt->rx_regs, rx_reg);
+	return true;
+}
+
+static bool uart_io_dereg(struct mesh_io *mesh_io, const uint8_t *filter,
+								uint8_t len)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct pvt_rx_reg *rx_reg;
+
+	rx_reg = l_queue_remove_if(pvt->rx_regs, find_by_filter, filter);
+
+	if (rx_reg)
+		l_free(rx_reg);
+
+	return true;
+}
+
+static bool find_by_pattern(const void *a, const void *b)
+{
+	const struct tx_pkt *tx = a;
+	const struct tx_pattern *pattern = b;
+
+	if (tx->len < pattern->len)
+		return false;
+
+	return (!memcmp(tx->data, pattern->data, pattern->len));
+}
+
+static bool uart_io_cancel(struct mesh_io *mesh_io,
+			const uint8_t *data, uint8_t len)
+{
+	struct mesh_io_private *pvt = mesh_io->pvt;
+	struct tx_pkt *tx;
+
+	const struct tx_pattern pattern = {
+		.data = data,
+		.len = len
+	};
+
+	if (!data)
+		return false;
+
+	do {
+		tx = l_queue_remove_if(pvt->tx_pkts, find_by_pattern, &pattern);
+		l_free(tx);
+	} while (tx);
+
+	tx = l_queue_peek_head(pvt->tx_pkts);
+
+	if (tx)
+		l_timeout_modify_ms(pvt->tx_timeout,
+						tx->instant - get_instant());
+	return true;
+}
+
+const struct mesh_io_api mesh_io_uart = {
+	.init = uart_io_init,
+	.destroy = uart_io_destroy,
+	.caps = uart_io_caps,
+	.send = uart_io_send,
+	.reg = uart_io_reg,
+	.dereg = uart_io_dereg,
+	.cancel = uart_io_cancel,
+};

--- a/mesh/mesh-io-uart.h
+++ b/mesh/mesh-io-uart.h
@@ -1,0 +1,20 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+
+extern const struct mesh_io_api mesh_io_uart;

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -31,10 +31,14 @@
 
 /* List of Mesh-IO Type headers */
 #include "mesh/mesh-io-generic.h"
+#include "mesh/mesh-io-uart.h"
+#include "mesh/mesh-io-tcpserver.h"
 
 /* List of Supported Mesh-IO Types */
 static const struct mesh_io_table table[] = {
-	{MESH_IO_TYPE_GENERIC,	&mesh_io_generic}
+	{MESH_IO_TYPE_GENERIC,		&mesh_io_generic},
+	{MESH_IO_TYPE_UART,		&mesh_io_uart},
+	{MESH_IO_TYPE_TCPSERVER,	&mesh_io_tcpserver}
 };
 
 static struct l_queue *io_list;

--- a/mesh/mesh-io.c
+++ b/mesh/mesh-io.c
@@ -25,6 +25,7 @@
 
 #include "lib/bluetooth.h"
 
+#include "mesh/dbus.h"
 #include "mesh/mesh-defs.h"
 #include "mesh/mesh-io.h"
 #include "mesh/mesh-io-api.h"
@@ -171,4 +172,15 @@ bool mesh_io_send_cancel(struct mesh_io *io, const uint8_t *pattern,
 		return io->api->cancel(io, pattern, len);
 
 	return false;
+}
+
+bool mesh_io_dbus_init(struct mesh_io *io, struct l_dbus *dbus)
+{
+	if (!io || !io->api)
+		return false;
+
+	if (io->api->dbus_init)
+		return io->api->dbus_init(io, dbus);
+
+	return true;
 }

--- a/mesh/mesh-io.h
+++ b/mesh/mesh-io.h
@@ -18,6 +18,7 @@
  */
 
 struct mesh_io;
+struct l_dbus;
 
 #define MESH_IO_TX_COUNT_UNLIMITED	0
 
@@ -100,3 +101,5 @@ bool mesh_io_send(struct mesh_io *io, struct mesh_io_send_info *info,
 					const uint8_t *data, uint16_t len);
 bool mesh_io_send_cancel(struct mesh_io *io, const uint8_t *pattern,
 								uint8_t len);
+
+bool mesh_io_dbus_init(struct mesh_io *io, struct l_dbus *dbus);

--- a/mesh/mesh-io.h
+++ b/mesh/mesh-io.h
@@ -23,7 +23,9 @@ struct mesh_io;
 
 enum mesh_io_type {
 	MESH_IO_TYPE_NONE = 0,
-	MESH_IO_TYPE_GENERIC
+	MESH_IO_TYPE_GENERIC,
+	MESH_IO_TYPE_UART,
+	MESH_IO_TYPE_TCPSERVER
 };
 
 enum mesh_io_timing_type {

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -72,7 +72,6 @@ struct join_data{
 	struct l_dbus_message *msg;
 	struct mesh_agent *agent;
 	char *sender;
-	const char *app_path;
 	struct mesh_node *node;
 	uint32_t disc_watch;
 	uint8_t *uuid;
@@ -445,7 +444,7 @@ static bool prov_complete_cb(void *user_data, uint8_t status,
 		return false;
 
 	owner = join_pending->sender;
-	path = join_pending->app_path;
+	path = node_get_app_path(join_pending->node);
 
 	if (status == PROV_ERR_SUCCESS &&
 	    !node_add_pending_local(join_pending->node, info))
@@ -551,7 +550,6 @@ static struct l_dbus_message *join_network_call(struct l_dbus *dbus,
 
 	join_pending->sender = l_strdup(sender);
 	join_pending->msg = l_dbus_message_ref(msg);
-	join_pending->app_path = app_path;
 
 	/* Try to create a temporary node */
 	node_join(app_path, sender, join_pending->uuid, node_init_cb);

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -429,6 +429,17 @@ static void send_join_failed(const char *owner, const char *path,
 	free_pending_join_call(true);
 }
 
+static void prov_join_complete_reply_cb(struct l_dbus_message *message,
+								void *user_data)
+{
+	bool failed = l_dbus_message_is_error(message);
+
+	if (!failed)
+		node_attach_io(join_pending->node, mesh.io);
+
+	free_pending_join_call(failed);
+}
+
 static bool prov_complete_cb(void *user_data, uint8_t status,
 					struct mesh_prov_node_info *info)
 {
@@ -455,7 +466,6 @@ static bool prov_complete_cb(void *user_data, uint8_t status,
 		return false;
 	}
 
-	node_attach_io(join_pending->node, mesh.io);
 	token = node_get_token(join_pending->node);
 
 	msg = l_dbus_message_new_method_call(dbus, owner, path,
@@ -463,10 +473,8 @@ static bool prov_complete_cb(void *user_data, uint8_t status,
 						"JoinComplete");
 
 	l_dbus_message_set_arguments(msg, "t", l_get_be64(token));
-
-	l_dbus_send(dbus, msg);
-
-	free_pending_join_call(false);
+	l_dbus_send_with_reply(dbus, msg,
+				prov_join_complete_reply_cb, NULL, NULL);
 
 	return true;
 }
@@ -660,11 +668,28 @@ static struct l_dbus_message *leave_call(struct l_dbus *dbus,
 	return l_dbus_message_new_method_return(msg);
 }
 
+static void create_join_complete_reply_cb(struct l_dbus_message *message,
+								void *user_data)
+{
+	struct mesh_node *node = user_data;
+
+	if (l_dbus_message_is_error(message)) {
+		node_remove(node);
+		return;
+	}
+
+	node_attach_io(node, mesh.io);
+}
+
 static void create_node_ready_cb(void *user_data, int status,
 							struct mesh_node *node)
 {
+	struct l_dbus *dbus = dbus_get_bus();
 	struct l_dbus_message *reply;
 	struct l_dbus_message *pending_msg;
+	struct l_dbus_message *msg;
+	const char *owner;
+	const char *path;
 	const uint8_t *token;
 
 	pending_msg = l_queue_find(pending_queue, simple_match, user_data);
@@ -673,20 +698,28 @@ static void create_node_ready_cb(void *user_data, int status,
 
 	if (status != MESH_ERROR_NONE) {
 		reply = dbus_error(pending_msg, status, NULL);
-		goto done;
+
+		l_dbus_send(dbus_get_bus(), reply);
+		l_queue_remove(pending_queue, pending_msg);
+		return;
 	}
 
-	node_attach_io(node, mesh.io);
-
 	reply = l_dbus_message_new_method_return(pending_msg);
+
+	l_dbus_send(dbus, reply);
+	l_queue_remove(pending_queue, pending_msg);
+
+	owner = l_dbus_message_get_sender(pending_msg);
+	path = node_get_app_path(node);
 	token = node_get_token(node);
 
-	l_debug();
-	l_dbus_message_set_arguments(reply, "t", l_get_be64(token));
+	msg = l_dbus_message_new_method_call(dbus, owner, path,
+						MESH_APPLICATION_INTERFACE,
+						"JoinComplete");
 
-done:
-	l_dbus_send(dbus_get_bus(), reply);
-	l_queue_remove(pending_queue, pending_msg);
+	l_dbus_message_set_arguments(msg, "t", l_get_be64(token));
+	l_dbus_send_with_reply(dbus, msg,
+				create_join_complete_reply_cb, node, NULL);
 }
 
 static struct l_dbus_message *create_network_call(struct l_dbus *dbus,
@@ -840,11 +873,11 @@ static void setup_network_interface(struct l_dbus_interface *iface)
 								"token");
 
 	l_dbus_interface_method(iface, "CreateNetwork", 0, create_network_call,
-					"t", "oay", "token", "app", "uuid");
+					"", "oay", "app", "uuid");
 
 	l_dbus_interface_method(iface, "Import", 0,
 					import_call,
-					"t", "oayayayqa{sv}uq", "token",
+					"", "oayayayqa{sv}uq",
 					"app", "uuid", "dev_key", "net_key",
 					"net_index", "flags", "iv_index",
 					"unicast");

--- a/mesh/mesh.c
+++ b/mesh/mesh.c
@@ -872,7 +872,7 @@ bool mesh_dbus_init(struct l_dbus *dbus)
 
 	l_info("Added Network Interface on %s", BLUEZ_MESH_PATH);
 
-	return true;
+	return mesh_io_dbus_init(mesh.io, dbus);
 }
 
 const char *mesh_get_storage_dir(void)

--- a/mesh/net-keys.c
+++ b/mesh/net-keys.c
@@ -239,6 +239,9 @@ uint32_t net_key_decrypt(uint32_t iv_index, const uint8_t *pkt, size_t len,
 	}
 
 	cache_id = 0;
+	if (len > sizeof(cache_pkt))
+		goto done;
+
 	memcpy(cache_pkt, pkt, len);
 	cache_len = len;
 	cache_iv_index = iv_index;

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -2102,6 +2102,47 @@ static struct l_dbus_message *vendor_publish_call(struct l_dbus *dbus,
 	return  l_dbus_message_new_method_return(msg);
 }
 
+static struct l_dbus_message *update_seq_num_call(struct l_dbus *dbus,
+						struct l_dbus_message *msg,
+						void *user_data)
+{
+	struct mesh_node *node = user_data;
+	struct mesh_net *net = node_get_net(node);
+	uint32_t current_seq_num = mesh_net_get_seq_num(net);
+	const char *sender = l_dbus_message_get_sender(msg);
+	uint32_t requested_seq_num;
+	struct l_dbus_message *reply;
+	struct l_dbus_message_builder *builder;
+
+	if (strcmp(sender, node->owner))
+		return dbus_error(msg, MESH_ERROR_NOT_AUTHORIZED, NULL);
+
+	if (!l_dbus_message_get_arguments(msg, "u", &requested_seq_num))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	l_debug("Requested sequence number: %u", requested_seq_num);
+
+	/* Do not allow to set sequence number above IV index update level */
+	if (requested_seq_num > SEQ_MASK)
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	reply = l_dbus_message_new_method_return(msg);
+	builder = l_dbus_message_builder_new(reply);
+
+	if (requested_seq_num > current_seq_num) {
+		mesh_net_set_seq_num(net, requested_seq_num);
+		l_dbus_message_builder_append_basic(builder, 'u',
+							&requested_seq_num);
+	} else
+		l_dbus_message_builder_append_basic(builder, 'u',
+							&current_seq_num);
+
+
+	l_dbus_message_builder_finalize(builder);
+	l_dbus_message_builder_destroy(builder);
+	return reply;
+}
+
 static bool features_getter(struct l_dbus *dbus, struct l_dbus_message *msg,
 					struct l_dbus_message_builder *builder,
 					void *user_data)
@@ -2183,9 +2224,9 @@ static bool seq_num_getter(struct l_dbus *dbus, struct l_dbus_message *msg,
 {
 	struct mesh_node *node = user_data;
 	struct mesh_net *net = node_get_net(node);
-	uint32_t seq_nr = mesh_net_get_seq_num(net);
+	uint32_t seq_num = mesh_net_get_seq_num(net);
 
-	l_dbus_message_builder_append_basic(builder, 'u', &seq_nr);
+	l_dbus_message_builder_append_basic(builder, 'u', &seq_num);
 
 	return true;
 }
@@ -2251,7 +2292,9 @@ static void setup_node_interface(struct l_dbus_interface *iface)
 	l_dbus_interface_method(iface, "VendorPublish", 0, vendor_publish_call,
 						"", "oqqay", "element_path",
 						"vendor", "model_id", "data");
-
+	l_dbus_interface_method(iface, "UpdateSequenceNumber", 0,
+					update_seq_num_call, "u", "u",
+					"seq_num", "seq_num");
 	l_dbus_interface_property(iface, "Features", 0, "a{sv}", features_getter,
 									NULL);
 	l_dbus_interface_property(iface, "Beacon", 0, "b", beacon_getter, NULL);

--- a/mesh/silvair-io.c
+++ b/mesh/silvair-io.c
@@ -1,0 +1,764 @@
+#ifndef __packed
+#define __packed __attribute__((packed))
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <ell/ell.h>
+
+#include "mesh/mesh-io.h"
+#include "mesh/mesh-io-api.h"
+#include "mesh/silvair-io.h"
+
+#define FRAME_BUFFER_SIZE 512
+#define SLIP_FRAME_BUFFER_SIZE ((2*FRAME_BUFFER_SIZE) + 2)
+#define OUT_RINGBUF_SIZE 4096
+
+#define SLIP_END	0300
+#define SLIP_ESC	0333
+#define SLIP_ESC_END	0334
+#define SLIP_ESC_ESC	0335
+
+static bool io_read_callback(struct l_io *l_io, void *user_data);
+
+static const uint32_t silvair_access_address		= 0x8e89bed6;
+static const uint16_t keep_alive_watchdog_period_ms	= 1000;
+static const uint16_t disconnect_watchdog_period_ms	= 10000;
+
+static const uint8_t silvair_channels[8] = {
+	0x00, 0x00, 0x00, 0x0e,
+	0x00, 0x00, 0x00, 0x00,
+};
+
+enum silvair_adv_type {
+	SILVAIR_ADV_TYPE_ADV_IND		= 0x00,
+	SILVAIR_ADV_TYPE_ADV_DIRECT_IND		= 0x01,
+	SILVAIR_ADV_TYPE_ADV_NONCONN_IND	= 0x02,
+};
+
+enum silvair_phy {
+	SILVAIR_PHY_1MBIT	= 0x03,
+	SILVAIR_PHY_2MBIT	= 0x04,
+	SILVAIR_PHY_NONE	= 0xff,
+};
+
+enum silvair_pwr {
+	SILVAIR_PWR_PLUS_8_DBM		= 0x08,
+	SILVAIR_PWR_PLUS_7_DBM		= 0x07,
+	SILVAIR_PWR_PLUS_6_DBM		= 0x06,
+	SILVAIR_PWR_PLUS_5_DBM		= 0x05,
+	SILVAIR_PWR_PLUS_4_DBM		= 0x04,
+	SILVAIR_PWR_PLUS_3_DBM		= 0x03,
+	SILVAIR_PWR_PLUS_2_DBM		= 0x02,
+	SILVAIR_PWR_ZERO_DBM		= 0x00,
+	SILVAIR_PWR_MINUS_4_DB		= 0xFC,
+	SILVAIR_PWR_MINUS_8_DBM		= 0xF8,
+	SILVAIR_PWR_MINUS_12_DBM	= 0xF4,
+	SILVAIR_PWR_MINUS_16_DBM	= 0xF0,
+	SILVAIR_PWR_MINUS_20_DBM	= 0xEC,
+	SILVAIR_PWR_MINUS_30_DBM	= 0xFF,
+	SILVAIR_PWR_MINUS_40_DBM	= 0xD8,
+};
+
+enum silvair_pkt_type {
+	SILVAIR_EVT_RX		= 0x06,
+	SILVAIR_CMD_TX		= 0x18,
+	SILVAIR_CMD_RX		= 0x19,
+	SILVAIR_CMD_BOOTLOADER	= 0x1A,
+	SILVAIR_CMD_FILTER	= 0x1B,
+	SILVAIR_EVT_RESET	= 0x1C,
+	SILVAIR_CMD_KEEP_ALIVE	= 0x1D,
+};
+
+struct silvair_pkt_hdr {
+	uint8_t			hdr_len;
+	uint8_t			pld_len;
+	uint8_t			version;
+	uint16_t		counter;
+	enum silvair_pkt_type	type:8;
+} __packed;
+
+struct silvair_rx_evt_hdr {
+	uint8_t		hdr_len;
+	uint8_t		crc;
+	uint8_t		channel;
+	uint8_t		rssi;
+	uint16_t	counter;
+	uint32_t	timestamp;
+} __packed;
+
+struct silvair_adv_hdr {
+	uint8_t	type:4;
+	uint8_t	__rfu1:2;
+	uint8_t	tx_add:1;
+	uint8_t	rx_add:1;
+	uint8_t	size:6;
+	uint8_t	__rfu2:2;
+} __packed;
+
+struct silvair_rx_evt_pld {
+	uint32_t		access_address;
+	struct silvair_adv_hdr	header;
+	uint8_t			__unused;
+	uint8_t			address[6];
+	uint8_t			adv_data[0];
+} __packed;
+
+struct silvair_tx_cmd_hdr {
+	uint8_t			hdr_len;
+	uint8_t			channels[8];
+	enum silvair_phy	phy:8;
+	enum silvair_pwr	pwr:8;
+	uint16_t		counter;
+} __packed;
+
+struct silvair_tx_cmd_pld {
+	uint32_t		access_address;
+	struct silvair_adv_hdr	header;
+	uint8_t			__unused;
+	uint8_t			address[6];
+	uint8_t			adv_data[0];
+} __packed;
+
+struct silvair_keep_alive_cmd_pld {
+	uint8_t		silvair_version_len;
+
+	/* Max supported version: AA.BB.CC-rcDD-12345678\0*/
+	char		silvair_version[23];
+	uint32_t	reset_reason;
+	uint32_t	uptime;
+	uint8_t		last_fault_len;
+	uint8_t		last_fault[128];
+} __packed;
+
+
+static void io_error_callback(void *user_data)
+{
+	struct silvair_io *io = user_data;
+
+	if (io->error_cb)
+		io->error_cb(io);
+}
+
+static int io_write_tls(struct silvair_io *io, uint8_t *buf, size_t buf_len)
+{
+	int err;
+	int ret;
+
+	if (io->tls_read_wants_write) {
+		io->tls_read_wants_write = false;
+
+		l_io_set_read_handler(io->l_io, io_read_callback, io, NULL);
+	}
+
+	ret = SSL_write(io->tls_conn, buf, buf_len);
+	err = SSL_get_error(io->tls_conn, ret);
+
+	if (err == SSL_ERROR_WANT_READ) {
+		io->tls_write_wants_read = true;
+
+		l_io_set_write_handler(io->l_io, NULL, NULL, NULL);
+		l_io_set_read_handler(io->l_io, io_read_callback, io, NULL);
+	}
+
+	return ret;
+}
+
+static bool io_write_callback(struct l_io *l_io, void *user_data)
+{
+	struct silvair_io *io = user_data;
+
+	if (io->tls_conn) {
+		int ret;
+		void *buf;
+		size_t buf_len;
+
+		buf = l_ringbuf_peek(io->out_ringbuf, 0, &buf_len);
+
+		ret = io_write_tls(io, buf, buf_len);
+
+		switch (SSL_get_error(io->tls_conn, ret)) {
+		case SSL_ERROR_WANT_READ:
+		case SSL_ERROR_WANT_WRITE:
+			return true;
+
+		case SSL_ERROR_NONE:
+			break;
+
+		default:
+			goto error;
+		}
+
+		l_ringbuf_drain(io->out_ringbuf, ret);
+	} else {
+		(void)l_ringbuf_write(io->out_ringbuf, l_io_get_fd(l_io));
+	}
+
+	return l_ringbuf_len(io->out_ringbuf);
+
+error:
+	io_error_callback(io);
+	return false;
+}
+
+static bool simple_write(struct silvair_io *io,
+				uint8_t *buf,
+				size_t size)
+{
+	if (l_ringbuf_avail(io->out_ringbuf) < size) {
+		l_warn("Write failed. Not enough space in the buffer.");
+		return false;
+	}
+
+	(void)l_ringbuf_append(io->out_ringbuf, buf, size);
+
+	return l_io_set_write_handler(io->l_io, io_write_callback, io, NULL);
+}
+
+static bool slip_write(struct silvair_io *io, uint8_t *buf, size_t size)
+{
+	static uint8_t end = SLIP_END;
+	static uint8_t esc_end[2] = { SLIP_ESC, SLIP_ESC_END };
+	static uint8_t esc_esc[2] = { SLIP_ESC, SLIP_ESC_ESC };
+
+	uint8_t slip_buf[SLIP_FRAME_BUFFER_SIZE] = { 0 };
+	size_t idx = 0;
+
+	slip_buf[idx++] = end;
+
+	for (uint8_t *i = buf; i != buf + size; ++i) {
+		switch (*i) {
+		case SLIP_END:
+			if (idx + sizeof(esc_end) >= sizeof(slip_buf))
+				return false;
+
+			memcpy(slip_buf + idx, esc_end, sizeof(esc_end));
+			idx += sizeof(esc_end);
+			break;
+
+		case SLIP_ESC:
+			if (idx + sizeof(esc_esc) >= sizeof(slip_buf))
+				return false;
+
+			memcpy(slip_buf + idx, esc_esc, sizeof(esc_esc));
+			idx += sizeof(esc_esc);
+			break;
+
+		default:
+			if (idx + sizeof(*i) >= sizeof(slip_buf))
+				return false;
+
+			slip_buf[idx++] = *i;
+			break;
+		}
+	}
+
+	if (idx + sizeof(end) >= sizeof(slip_buf))
+		return false;
+
+	slip_buf[idx++] = end;
+
+	return simple_write(io, slip_buf, idx);
+}
+
+static bool io_write(struct silvair_io *io,
+				uint8_t *buf,
+				size_t size)
+{
+	if (io->slip.kernel_support)
+		return simple_write(io, buf, size);
+	else
+		return slip_write(io, buf, size);
+}
+
+static void process_evt_rx(struct silvair_io *io,
+				const struct silvair_pkt_hdr *pkt_hdr,
+				size_t len,
+				void *user_data)
+{
+	const struct silvair_rx_evt_hdr *rx_hdr;
+	const struct silvair_rx_evt_pld *rx_pld;
+	const uint8_t *adv;
+	int8_t rssi;
+
+	if (len < sizeof(*rx_hdr))
+		return;
+
+	rx_hdr = (struct silvair_rx_evt_hdr *)(pkt_hdr + 1);
+	len -= sizeof(*rx_hdr);
+
+	if (len < sizeof(*rx_pld))
+		return;
+
+	rssi = rx_hdr->rssi;
+	rx_pld = (struct silvair_rx_evt_pld *)(rx_hdr + 1);
+
+	adv = rx_pld->adv_data;
+
+	while (adv < (const uint8_t *)rx_pld + pkt_hdr->pld_len) {
+		uint8_t field_len = adv[0];
+
+		/* Check for the end of advertising data */
+		if (field_len == 0)
+			break;
+
+		/* Do not continue data parsing if got incorrect length */
+		if (adv + field_len + 1 >
+			(const uint8_t *)rx_pld + pkt_hdr->pld_len)
+			break;
+
+		io->process_rx_cb(io, rssi, adv + 1, field_len, user_data);
+		adv += field_len + 1;
+	}
+}
+
+static void process_evt_keep_alive(struct silvair_io *io,
+				const struct silvair_pkt_hdr *pkt_hdr,
+				size_t len)
+{
+	const struct silvair_keep_alive_cmd_pld *keep_alive_pld;
+
+	keep_alive_pld = (struct silvair_keep_alive_cmd_pld *)(pkt_hdr + 1);
+
+	l_info("Version: %s, uptime %u", keep_alive_pld->silvair_version,
+							keep_alive_pld->uptime);
+}
+
+static void process_packet(struct silvair_io *io,
+				uint8_t *buf,
+				size_t size,
+				void *user_data)
+{
+	const struct silvair_pkt_hdr *pkt_hdr;
+	size_t len = size;
+
+	if (len < sizeof(*pkt_hdr))
+		return;
+
+	pkt_hdr = (struct silvair_pkt_hdr *)buf;
+	len -= sizeof(*pkt_hdr);
+
+	if (len < pkt_hdr->pld_len)
+		return;
+
+	switch (pkt_hdr->type) {
+
+	case SILVAIR_EVT_RX:
+		process_evt_rx(io, pkt_hdr, len, user_data);
+		break;
+
+	case SILVAIR_CMD_KEEP_ALIVE:
+		if (io->disconnect_watchdog) {
+			l_timeout_remove(io->disconnect_watchdog);
+			io->disconnect_watchdog = NULL;
+		}
+		process_evt_keep_alive(io, pkt_hdr, len);
+		break;
+
+	case SILVAIR_EVT_RESET:
+	case SILVAIR_CMD_TX:
+	case SILVAIR_CMD_RX:
+	case SILVAIR_CMD_BOOTLOADER:
+	case SILVAIR_CMD_FILTER:
+		break;
+	}
+}
+
+static void process_slip(struct silvair_io *io,
+				uint8_t *buf,
+				size_t size,
+				void *user_data)
+{
+	struct slip *slip = &io->slip;
+
+	for (uint8_t *i = buf; i != buf + size; ++i) {
+		switch (*i) {
+		case SLIP_END:
+			if (slip->offset)
+				process_packet(io, slip->buf, slip->offset,
+								user_data);
+			slip->offset = 0;
+			break;
+
+		case SLIP_ESC:
+			slip->esc = true;
+			break;
+
+		default:
+			if (!slip->esc) {
+				slip->buf[slip->offset++] = *i;
+				break;
+			}
+
+			switch (*i) {
+			case SLIP_ESC_ESC:
+				slip->buf[slip->offset++] = SLIP_ESC;
+				break;
+
+			case SLIP_ESC_END:
+				slip->buf[slip->offset++] = SLIP_END;
+				break;
+
+			default:
+				slip->offset = 0;
+			}
+
+			slip->esc = false;
+		}
+
+		if (slip->offset >= sizeof(slip->buf)) {
+			slip->offset = 0;
+			slip->esc = false;
+			return;
+		}
+	}
+}
+
+static int build_packet(uint8_t *data,
+				uint8_t *buf,
+				size_t size,
+				enum silvair_pkt_type type)
+{
+	struct silvair_pkt_hdr *pkt_hdr;
+
+	pkt_hdr = (struct silvair_pkt_hdr *)data;
+	pkt_hdr->hdr_len = sizeof(*pkt_hdr);
+	pkt_hdr->pld_len = 0;
+	pkt_hdr->version = 1;
+	pkt_hdr->counter = 0;
+	pkt_hdr->type = type;
+
+	if (pkt_hdr->type == SILVAIR_CMD_TX) {
+		// ADV_NONCONN_IND = <AdvA> | <AdvData>
+		// <AdvA> - 6 bytes of address
+		// <AdvData> = <Len> | <Type> | <Value>
+		// <Len> = len(<Type>) + len(<Value>)
+		// len(<AdvData>) = <Len> + len(<Len>)
+		// "+ 1" below means length of <Len> field
+		size_t adv_data_len = size + 1;
+
+		struct silvair_tx_cmd_hdr *tx_hdr;
+		struct silvair_tx_cmd_pld *tx_pld;
+		uint8_t *adv_data;
+
+		tx_hdr = (struct silvair_tx_cmd_hdr *)(pkt_hdr + 1);
+		tx_pld = (struct silvair_tx_cmd_pld *)(tx_hdr + 1);
+		adv_data = tx_pld->adv_data;
+
+		pkt_hdr->pld_len = sizeof(*tx_hdr) + sizeof(*tx_pld) +
+								adv_data_len;
+
+		tx_hdr->hdr_len = sizeof(*tx_hdr);
+		memcpy(tx_hdr->channels, silvair_channels,
+						sizeof(tx_hdr->channels));
+		tx_hdr->phy = SILVAIR_PHY_1MBIT;
+		tx_hdr->pwr = SILVAIR_PWR_MINUS_8_DBM;
+
+		tx_pld->access_address = htole32(silvair_access_address);
+
+		tx_pld->header.type = SILVAIR_ADV_TYPE_ADV_NONCONN_IND;
+
+		tx_pld->header.size = sizeof(tx_pld->address) + adv_data_len;
+		tx_hdr->counter = 0;
+
+		l_getrandom(tx_pld->address, sizeof(tx_pld->address));
+		tx_pld->address[5] |= 0xc0;
+
+		adv_data[0] = size;
+		memcpy(adv_data + 1, buf, size);
+	}
+
+	if (pkt_hdr->type == SILVAIR_CMD_KEEP_ALIVE) {
+		struct silvair_keep_alive_cmd_pld *keep_alive_pld;
+
+		keep_alive_pld =
+			(struct silvair_keep_alive_cmd_pld *)(pkt_hdr + 1);
+		memset(keep_alive_pld, 0, sizeof(*keep_alive_pld));
+
+		pkt_hdr->pld_len = sizeof(*keep_alive_pld);
+	}
+
+	return pkt_hdr->hdr_len + pkt_hdr->pld_len;
+}
+
+static bool send_message(struct silvair_io *io,
+				uint8_t *buf,
+				size_t size)
+{
+	int len = 0;
+	uint8_t data[FRAME_BUFFER_SIZE] = { 0 };
+
+	len = build_packet(&data[0], buf, size, SILVAIR_CMD_TX);
+	return io_write(io, data, len);
+}
+
+static bool send_keep_alive_request(struct silvair_io *io,
+				uint8_t *buf,
+				size_t size)
+{
+	int len = 0;
+	uint8_t data[FRAME_BUFFER_SIZE] = { 0 };
+
+	len = build_packet(&data[0], buf, size, SILVAIR_CMD_KEEP_ALIVE);
+	return io_write(io, data, len);
+}
+
+static void silvair_process_rx(struct silvair_io *io,
+			uint8_t *buf,
+			size_t size,
+			void *user_data)
+{
+	if (io->slip.kernel_support)
+		process_packet(io, buf, size, user_data);
+	else
+		process_slip(io, buf, size, user_data);
+}
+
+static int io_read_tls(struct silvair_io *io, uint8_t *buf, size_t buf_len)
+{
+	int err;
+	int ret;
+
+	if (io->tls_write_wants_read) {
+		io->tls_write_wants_read = false;
+
+		l_io_set_write_handler(io->l_io, io_write_callback, io, NULL);
+	}
+
+	ret = SSL_read(io->tls_conn, buf, buf_len);
+	err = SSL_get_error(io->tls_conn, ret);
+
+	if (err == SSL_ERROR_WANT_WRITE) {
+		io->tls_read_wants_write = true;
+
+		l_io_set_read_handler(io->l_io, NULL, NULL, NULL);
+		l_io_set_write_handler(io->l_io, io_write_callback, io, NULL);
+	}
+
+	return ret;
+}
+
+static bool io_read_callback(struct l_io *l_io, void *user_data)
+{
+	struct silvair_io *io = user_data;
+	struct mesh_io *mesh_io = io->context;
+	uint8_t buf[512];
+	int r, fd;
+
+	fd = l_io_get_fd(l_io);
+
+	if (fd < 0) {
+		l_error("l_io_get_fd error");
+		goto error;
+	}
+
+	if (io->tls_conn) {
+		r = io_read_tls(io, buf, sizeof(buf));
+
+		switch (SSL_get_error(io->tls_conn, r)) {
+		case SSL_ERROR_WANT_READ:
+		case SSL_ERROR_WANT_WRITE:
+			return true;
+
+		case SSL_ERROR_NONE:
+			break;
+
+		default:
+			goto error;
+		}
+	} else {
+		r = read(fd, buf, sizeof(buf));
+
+		if (r <= 0) {
+
+			if (r != 0) {
+				l_error("read error");
+				goto error;
+			}
+
+			/* Disconnect and remove client from the queue */
+			goto error;
+		}
+	}
+
+	silvair_process_rx(io, buf, r, mesh_io);
+	return true;
+
+error:
+	io_error_callback(io);
+	return false;
+}
+
+static void io_disconnect_callback(struct l_io *l_io, void *user_data)
+{
+	struct silvair_io *io = user_data;
+
+	if (io->disconnect_cb)
+		io->disconnect_cb(io);
+
+}
+
+static void sivair_io_send_keepalive(struct silvair_io *io)
+{
+	if (!send_keep_alive_request(io, NULL, 0)) {
+		l_error("write failed: %s", strerror(errno));
+		io_error_callback(io);
+	}
+}
+
+/* This is the communication related timer's callback. It waits for the
+ * specified amount of time for the SILVAIR_CMD_KEEP_ALIVE response from
+ * the client.
+ *
+ * The timer will be stopped and cleared when:
+ *    - SILVAIR_CMD_KEEP_ALIVE response has been received
+ *    - keep_alive_message_timeout() has been refreshed when new mesh packed
+ *      has been received
+ */
+static void keep_alive_communication_timeout(struct l_timeout *timeout,
+								void *user_data)
+{
+	l_error("Keep alive error");
+	io_error_callback(user_data);
+}
+
+/* This is the internal keep alive timer's callback which should be refreshed
+ * when new mesh packet has been received. The refresh can be performed by
+ * calling the silvair_io_keep_alive_wdt_refresh() function.
+ *
+ * When the internal keep_alive_message_timeout() timeouts, the
+ * keep_alive_communication_timeout() timer is started in order to check if the
+ * UART or ETH cable is connected
+ */
+static void keep_alive_message_timeout(struct l_timeout *timeout,
+								void *user_data)
+{
+	/* No mesh messages occurred in specified amount of the time.
+	 * Check if the communication is still set up
+	 */
+	struct silvair_io *io = user_data;
+
+	l_info("Keep alive: checking for the communication fd %d...",
+							l_io_get_fd(io->l_io));
+
+	/* Send keep alive request */
+	sivair_io_send_keepalive(io);
+	io->disconnect_watchdog =
+		l_timeout_create_ms(disconnect_watchdog_period_ms,
+				keep_alive_communication_timeout, io, NULL);
+}
+
+void silvair_io_send_message(struct silvair_io *io, uint8_t *buf, size_t size)
+{
+	if (!send_message(io, buf, size))
+		l_error("write failed: %s", strerror(errno));
+}
+
+struct silvair_io *silvair_io_new(int fd,
+				bool kernel_support,
+				process_packet_cb rx_cb,
+				io_error_cb error_cb,
+				io_disconnect_cb disc_cb,
+				void *context, SSL *tls_conn)
+{
+	struct silvair_io *io = l_new(struct silvair_io, 1);
+
+	if (!rx_cb) {
+		l_error("initialization failed: process_rx_cb is NULL");
+		return NULL;
+	}
+
+	io->context = context;
+	io->slip.offset = 0;
+	io->slip.esc = false;
+
+	io->l_io = l_io_new(fd);
+	io->slip.kernel_support = kernel_support;
+
+	io->out_ringbuf = l_ringbuf_new(OUT_RINGBUF_SIZE);
+
+	io->process_rx_cb = rx_cb;
+	io->error_cb = error_cb;
+	io->tls_conn = tls_conn;
+
+	/* io read destroy callback will be called when io_read_callback */
+	 /* return false */
+	if (!l_io_set_read_handler(io->l_io, io_read_callback, io, NULL)) {
+		l_error("l_io_set_read_handler failed");
+		return false;
+	}
+
+	io->disconnect_cb = disc_cb;
+	if (!l_io_set_disconnect_handler(io->l_io, io_disconnect_callback, io,
+								NULL)) {
+		l_error("l_io_set_disconnect_handler failed");
+		return false;
+	}
+
+	io->keep_alive_watchdog =
+		l_timeout_create_ms(keep_alive_watchdog_period_ms,
+					keep_alive_message_timeout, io, NULL);
+
+	/* Send keep alive request */
+	sivair_io_send_keepalive(io);
+	return io;
+}
+
+void silvair_io_keep_alive_wdt_refresh(struct silvair_io *io)
+{
+	if (!io)
+		return;
+
+	if (!io->keep_alive_watchdog)
+		return;
+
+	if (io->disconnect_watchdog) {
+		l_timeout_remove(io->disconnect_watchdog);
+		io->disconnect_watchdog = NULL;
+		l_info("Connection OK");
+	}
+
+	l_timeout_modify_ms(io->keep_alive_watchdog,
+					keep_alive_watchdog_period_ms);
+}
+
+int silvair_io_get_fd(struct silvair_io *io)
+{
+	return l_io_get_fd(io->l_io);
+}
+
+void silvair_io_destroy(struct silvair_io *io)
+{
+	if (!io)
+		return;
+
+	io_error_callback(io);
+
+	if (io->l_io)
+		l_io_destroy(io->l_io);
+
+	if (io->out_ringbuf)
+		l_ringbuf_free(io->out_ringbuf);
+
+	if (io->keep_alive_watchdog)
+		l_timeout_remove(io->keep_alive_watchdog);
+
+	if (io->disconnect_watchdog)
+		l_timeout_remove(io->disconnect_watchdog);
+
+	if (io->tls_conn)
+		SSL_free(io->tls_conn);
+}
+
+void silvair_io_close(struct silvair_io *io)
+{
+	int fd = silvair_io_get_fd(io);
+
+	shutdown(fd, SHUT_WR);
+}

--- a/mesh/silvair-io.h
+++ b/mesh/silvair-io.h
@@ -1,0 +1,81 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2019  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+#include <openssl/ssl.h>
+
+struct silvair_io;
+struct l_io;
+struct l_timeout;
+
+typedef void (*process_packet_cb)(struct silvair_io *io,
+				  int8_t rssi,
+				  const uint8_t *data,
+				  uint8_t len,
+				  void *user_data);
+
+typedef void (*keep_alive_tmout_cb)(struct l_timeout *timeout, void *user_data);
+typedef void (*io_disconnect_cb)(struct silvair_io *io);
+typedef void (*io_error_cb)(struct silvair_io *io);
+
+struct slip {
+	uint8_t	buf[512];
+	size_t	offset;
+	bool	esc;
+	bool	kernel_support;
+};
+
+struct silvair_io {
+	struct l_io		*l_io;
+	struct l_ringbuf	*out_ringbuf;
+
+	struct l_timeout	*keep_alive_watchdog;
+	struct l_timeout	*disconnect_watchdog;
+
+	io_disconnect_cb	disconnect_cb;
+	io_error_cb		error_cb;
+
+	struct slip		slip;
+	process_packet_cb	process_rx_cb;
+	void *context;
+
+	SSL                     *tls_conn;
+	bool                    tls_read_wants_write;
+	bool                    tls_write_wants_read;
+};
+
+struct silvair_io *silvair_io_new(int fd,
+				bool kernel_support,
+				process_packet_cb rx_cb,
+				io_error_cb read_failed_cb,
+				io_disconnect_cb disc_cb,
+				void *context,
+				SSL *tls_conn);
+
+int silvair_io_get_fd(struct silvair_io *io);
+
+void silvair_io_destroy(struct silvair_io *io);
+
+void silvair_io_keep_alive_wdt_refresh(struct silvair_io *io);
+
+void silvair_io_send_message(struct silvair_io *io, uint8_t *buf, size_t size);
+
+void silvair_io_close(struct silvair_io *io);

--- a/mesh/tcpserver-acl.c
+++ b/mesh/tcpserver-acl.c
@@ -1,0 +1,548 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2020  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#include "tcpserver-acl.h"
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include <ell/ell.h>
+#include <json-c/json.h>
+
+#include "mesh/dbus.h"
+#include "mesh/error.h"
+#include "mesh/crypto.h"
+#include "mesh/util.h"
+
+#include "config.h"
+
+#define UUID_LEN (16)
+#define DEV_KEY_LEN (16)
+#define NET_KEY_LEN (16)
+#define IDENTITY_LEN (16)
+#define PSK_LEN (16)
+
+
+static const char *TCPSERVER_ACL_IFACE = "org.bluez.mesh.AccessControlList1";
+
+
+struct tcpserver_acl {
+	char			*config_path;
+	const char		*dbus_path;
+	struct l_queue		*entries;
+	void			*user_data;
+	on_acl_entry_changed	on_acl_entry_changed_callback;
+};
+
+struct acl_entry {
+	uint64_t	token;
+	uint8_t		identity[IDENTITY_LEN];
+	uint8_t		psk[PSK_LEN];
+};
+
+
+static bool calc_identity(const uint8_t *uuid, const uint8_t *net_key,
+			  uint8_t *identity)
+{
+	uint8_t net_id[8];
+	char s1_info[24];
+
+	// net_id = k3(net_key)
+	if (!mesh_crypto_k3(net_key, net_id))
+		return false;
+
+	// s1_info = (uuid|net_id)
+	memcpy(s1_info, uuid, UUID_LEN);
+	memcpy(s1_info + UUID_LEN, net_id, sizeof(net_id));
+
+	// id = s1(s1_info)
+	if (!mesh_crypto_s1(s1_info, sizeof(s1_info), identity))
+		return false;
+
+	return true;
+}
+
+static bool calc_psk(const uint8_t *identity, const uint8_t *dev_key,
+		     uint8_t *psk)
+{
+	const char k1_info[] = { 'i', 'd', 'p', 's', 'k' };
+
+	// psk = k1(dev_key, identity, "idpsk")
+	if (!mesh_crypto_k1(dev_key, identity, k1_info, sizeof(k1_info), psk))
+		return false;
+
+	return true;
+}
+
+static bool acl_entry_fill(struct acl_entry *entry, const uint8_t *uuid,
+			   const uint8_t *dev_key, const uint8_t *net_key)
+{
+	if (!calc_identity(uuid, net_key, entry->identity))
+		return false;
+
+	if (!calc_psk(entry->identity, dev_key, entry->psk))
+		return false;
+
+	return true;
+}
+
+static bool match_identity(const void *a, const void *b)
+{
+	const struct acl_entry *entry = a;
+	const unsigned char *identity = b;
+
+	return !memcmp(entry->identity, identity, sizeof(entry->identity));
+}
+
+static struct acl_entry *acl_entry_find_by_identity(
+	struct l_queue *entries, const uint8_t *identity_buf)
+{
+	return l_queue_find(entries, match_identity, identity_buf);
+}
+
+static bool match_token(const void *a, const void *b)
+{
+	const struct acl_entry *entry = a;
+	const uint64_t *token = b;
+
+	return entry->token == *token;
+}
+
+static struct acl_entry *acl_entry_find_by_token(
+	struct l_queue *acl, uint64_t token)
+{
+	return l_queue_find(acl, match_token, &token);
+}
+
+static uint64_t acl_get_unique_token(struct l_queue *entries)
+{
+	uint64_t token;
+
+	do {
+		l_getrandom(&token, sizeof(token));
+	} while (acl_entry_find_by_token(entries, token));
+
+	return token;
+}
+
+static uint32_t acl_add_entry(
+	struct l_queue *entries, struct acl_entry *entry)
+{
+	if (acl_entry_find_by_identity(entries, entry->identity))
+		return MESH_ERROR_ALREADY_EXISTS;
+
+	if (!l_queue_push_tail(entries, entry))
+		return MESH_ERROR_FAILED;
+
+	return MESH_ERROR_NONE;
+}
+
+static bool write_hexstr(json_object *jobj, const char *key,
+			 void *buf, size_t buf_len)
+{
+	char str[33];
+	json_object *jstr;
+
+	if (!hex2str(buf, buf_len, str, 33))
+		return false;
+
+	jstr = json_object_new_string(str);
+	if (!jstr)
+		return false;
+
+	json_object_object_add(jobj, key, jstr);
+	return true;
+}
+
+static void adapter_cfg_write_acl_entry(void *data, void *user_data)
+{
+	struct acl_entry *entry = data;
+
+	json_object *jarray = user_data;
+	json_object *jobj;
+
+	jobj = json_object_new_object();
+	if (!jobj)
+		return;
+
+	if (!write_hexstr(jobj, "token", &entry->token, sizeof(entry->token)))
+		goto fail;
+
+	if (!write_hexstr(jobj, "identity", entry->identity, IDENTITY_LEN))
+		goto fail;
+
+	if (!write_hexstr(jobj, "psk", entry->psk, PSK_LEN))
+		goto fail;
+
+	json_object_array_add(jarray, jobj);
+	return;
+
+fail:
+	l_error("Failed to write ACL entry");
+
+	// Release memory allocated by JSON-c
+	json_object_put(jobj);
+	return;
+
+}
+
+static json_object *acl_to_json_cfg(struct tcpserver_acl *acl)
+{
+	json_object *jcfg;
+	json_object *jarray;
+
+	jcfg = json_object_new_object();
+	if (!jcfg)
+		return NULL;
+
+	jarray = json_object_new_array();
+	if (!jarray) {
+		// Release memory allocated by JSON-c
+		json_object_put(jcfg);
+
+		return NULL;
+	}
+
+	l_queue_foreach(acl->entries, adapter_cfg_write_acl_entry, jarray);
+
+	json_object_object_add(jcfg, "ACL", jarray);
+
+	return jcfg;
+}
+
+static bool save_config(struct tcpserver_acl *acl)
+{
+	FILE *outfile;
+	json_object *jcfg;
+	const char *str;
+	bool result = false;
+
+	outfile = fopen(acl->config_path, "w");
+	if (!outfile) {
+		l_error("Failed to save configuration to %s", acl->config_path);
+		return false;
+	}
+
+	jcfg = acl_to_json_cfg(acl);
+
+	str = json_object_to_json_string_ext(jcfg, JSON_C_TO_STRING_PRETTY);
+
+	if (fwrite(str, sizeof(char), strlen(str), outfile) < strlen(str))
+		l_warn("Incomplete write of adapter configuration");
+	else
+		result = true;
+
+	fclose(outfile);
+
+	return result;
+}
+
+static bool read_hexstr_data(json_object *jobj, const char *key,
+			     void *buf, size_t buf_len)
+{
+	json_object *jval;
+	const char *str;
+
+	if (!json_object_object_get_ex(jobj, key, &jval))
+		return false;
+
+	str = json_object_get_string(jval);
+	if (!str)
+		return false;
+
+	return str2hex(str, strlen(str), buf, buf_len);
+}
+
+static struct acl_entry *adapter_cfg_parse_acl_entry(json_object *jobj)
+{
+	struct acl_entry *entry = l_new(struct acl_entry, 1);
+
+	if (!read_hexstr_data(jobj, "token", &entry->token, sizeof(uint64_t)))
+		goto fail;
+
+	if (!read_hexstr_data(jobj, "identity", entry->identity, IDENTITY_LEN))
+		goto fail;
+
+	if (!read_hexstr_data(jobj, "psk", entry->psk, PSK_LEN))
+		goto fail;
+
+	return entry;
+
+fail:
+	l_error("Failed to parse ACL entry");
+
+	l_free(entry);
+	return NULL;
+}
+
+static bool set_json_config(struct tcpserver_acl *acl, json_object *jcfg)
+{
+	struct acl_entry	*entry;
+	json_object		*jentry;
+	json_object		*jarray;
+	size_t			array_len;
+	uint32_t		err;
+
+	json_object_object_get_ex(jcfg, "ACL", &jarray);
+	if (!jarray || json_object_get_type(jarray) != json_type_array)
+		return false;
+
+	array_len = json_object_array_length(jarray);
+
+	for (size_t i = 0; i < array_len; i++) {
+		jentry = json_object_array_get_idx(jarray, i);
+		if (!jentry)
+			goto fail;
+
+		entry = adapter_cfg_parse_acl_entry(jentry);
+		if (!entry)
+			goto fail;
+
+		err = acl_add_entry(acl->entries, entry);
+		if (err != MESH_ERROR_NONE) {
+			l_free(entry);
+			goto fail;
+		}
+
+		if (acl->on_acl_entry_changed_callback)
+			acl->on_acl_entry_changed_callback(acl,
+							   entry->identity,
+							   acl->user_data,
+							   false);
+
+		l_debug("Added ACL entry with token: '%ju'", entry->token);
+	}
+
+	return true;
+fail:
+
+	l_queue_clear(acl->entries, l_free);
+	return false;
+}
+
+static bool load_config(struct tcpserver_acl *acl)
+{
+	int fd;
+	char *str;
+	struct stat st;
+	ssize_t sz;
+	json_object *jcfg;
+
+	fd = open(acl->config_path, O_RDONLY);
+	if (fd < 0)
+		return false;
+
+	if (fstat(fd, &st) == -1) {
+		close(fd);
+		return false;
+	}
+
+	str = l_new(char, st.st_size + 1);
+
+	sz = read(fd, str, st.st_size);
+	if (sz != st.st_size) {
+		l_error("Failed to read configuration file %s",
+			acl->config_path);
+		close(fd);
+		return false;
+	}
+
+	jcfg = json_tokener_parse(str);
+
+	close(fd);
+	l_free(str);
+
+	return set_json_config(acl, jcfg);
+}
+
+static struct l_dbus_message *grant_access_call(struct l_dbus *dbus,
+						struct l_dbus_message *msg,
+						void *user_data)
+{
+	struct tcpserver_acl *acl = user_data;
+
+	struct acl_entry *entry;
+	struct l_dbus_message *ret_msg;
+	struct l_dbus_message_iter iter_uuid;
+	struct l_dbus_message_iter iter_dev_key;
+	struct l_dbus_message_iter iter_net_key;
+
+	uint8_t *uuid;
+	uint8_t *dev_key;
+	uint8_t *net_key;
+	uint32_t n;
+	uint32_t err;
+
+	if (!l_dbus_message_get_arguments(msg, "ayayay", &iter_uuid,
+					  &iter_dev_key, &iter_net_key))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	if (!l_dbus_message_iter_get_fixed_array(&iter_uuid, &uuid, &n) ||
+	    (n != UUID_LEN))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	if (!l_dbus_message_iter_get_fixed_array(&iter_dev_key, &dev_key, &n)
+	    || (n != DEV_KEY_LEN))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	if (!l_dbus_message_iter_get_fixed_array(&iter_net_key, &net_key, &n)
+	    || (n != NET_KEY_LEN))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	entry = l_new(struct acl_entry, 1);
+
+	entry->token = acl_get_unique_token(acl->entries);
+
+	if (!acl_entry_fill(entry, uuid, dev_key, net_key)) {
+		l_free(entry);
+		return dbus_error(msg, MESH_ERROR_FAILED, NULL);
+	}
+
+	err = acl_add_entry(acl->entries, entry);
+	if (err != MESH_ERROR_NONE) {
+		l_free(entry);
+		return dbus_error(msg, err, NULL);
+	}
+
+	if (acl->on_acl_entry_changed_callback &&
+	    acl->on_acl_entry_changed_callback(acl,
+					       entry->identity,
+					       acl->user_data,
+					       false))
+		save_config(acl);
+
+	ret_msg = l_dbus_message_new_method_return(msg);
+
+	l_dbus_message_set_arguments(ret_msg, "t", entry->token);
+
+	return ret_msg;
+}
+
+static struct l_dbus_message *revoke_access_call(struct l_dbus *dbus,
+						struct l_dbus_message *msg,
+						void *user_data)
+{
+	struct tcpserver_acl *acl = user_data;
+	struct acl_entry *entry;
+
+	uint64_t token;
+
+	if (!l_dbus_message_get_arguments(msg, "t", &token))
+		return dbus_error(msg, MESH_ERROR_INVALID_ARGS, NULL);
+
+	entry = acl_entry_find_by_token(acl->entries, token);
+
+	if (!entry)
+		return dbus_error(msg, MESH_ERROR_NOT_FOUND, NULL);
+
+	if (!l_queue_remove(acl->entries, entry))
+		return dbus_error(msg, MESH_ERROR_NOT_FOUND, NULL);
+
+	if (acl->on_acl_entry_changed_callback &&
+	    acl->on_acl_entry_changed_callback(acl, entry->identity,
+					       acl->user_data, true))
+		save_config(acl);
+
+	l_free(entry);
+
+	return l_dbus_message_new_method_return(msg);
+}
+
+static void setup_acl_iface(struct l_dbus_interface *iface)
+{
+	l_dbus_interface_method(iface, "GrantAccess", 0, grant_access_call, "t",
+				"ayayay", "token", "uuid", "dev_key",
+				"net_key");
+
+	l_dbus_interface_method(iface, "RevokeAccess", 0, revoke_access_call,
+				"", "t", "token");
+}
+
+struct tcpserver_acl *tcpserver_acl_new(const char *config_dir,
+			const char *dbus_path,
+			on_acl_entry_changed on_acl_entry_changed_callback,
+			void *user_data)
+{
+	struct tcpserver_acl *acl;
+
+	acl			= l_new(struct tcpserver_acl, 1);
+	acl->config_path	= l_strdup_printf("%s/tcpserver_acl.conf",
+						config_dir ?: MESH_STORAGEDIR);
+	acl->dbus_path		= dbus_path;
+	acl->entries		= l_queue_new();
+	acl->user_data		= user_data;
+
+	acl->on_acl_entry_changed_callback = on_acl_entry_changed_callback;
+
+	load_config(acl);
+
+	return acl;
+}
+
+void tcpserver_acl_destroy(struct tcpserver_acl *acl)
+{
+	if (acl->entries)
+		l_queue_destroy(acl->entries, l_free);
+
+	if (acl->config_path)
+		l_free(acl->config_path);
+
+	l_free(acl);
+}
+
+bool tcpserver_acl_dbus_init(struct tcpserver_acl *acl, struct l_dbus *bus)
+{
+	if (!l_dbus_register_interface(bus, TCPSERVER_ACL_IFACE,
+				       setup_acl_iface, NULL, false)) {
+		l_info("Unable to register %s interface",
+		       TCPSERVER_ACL_IFACE);
+
+		return false;
+	}
+
+	if (!l_dbus_object_add_interface(bus, acl->dbus_path,
+					 TCPSERVER_ACL_IFACE, acl)) {
+		l_info("Unable to register the mesh object on '%s'",
+		       TCPSERVER_ACL_IFACE);
+
+		l_dbus_unregister_interface(bus, TCPSERVER_ACL_IFACE);
+		return false;
+	}
+
+	return true;
+}
+
+size_t tcpserver_acl_psk_get(struct tcpserver_acl *acl, const char *identity,
+			     uint8_t *psk, unsigned int max_psk_len)
+{
+	uint8_t			identity_buf[IDENTITY_LEN];
+	struct acl_entry	*entry;
+
+	if (!str2hex(identity, strlen(identity), identity_buf, IDENTITY_LEN))
+		return 0;
+
+	entry = acl_entry_find_by_identity(acl->entries, identity_buf);
+
+	if (!entry || max_psk_len < PSK_LEN)
+		return 0;
+
+	memcpy(psk, entry->psk, PSK_LEN);
+
+	return PSK_LEN;
+}

--- a/mesh/tcpserver-acl.h
+++ b/mesh/tcpserver-acl.h
@@ -1,0 +1,41 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2020  Silvair Inc. All rights reserved.
+ *
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ */
+#include <stddef.h>
+#include <stdbool.h>
+
+#include <ell/dbus.h>
+
+struct tcpserver_acl;
+
+
+typedef bool (*on_acl_entry_changed)(struct tcpserver_acl *acl,
+			     uint8_t *identity, void *user_data, bool removed);
+
+
+struct tcpserver_acl *tcpserver_acl_new(const char *config_dir,
+			const char *dbus_path,
+			on_acl_entry_changed on_acl_entry_changed_callback,
+			void *user_data);
+
+void tcpserver_acl_destroy(struct tcpserver_acl *acl);
+
+bool tcpserver_acl_dbus_init(struct tcpserver_acl *acl, struct l_dbus *bus);
+
+size_t tcpserver_acl_psk_get(struct tcpserver_acl *acl,
+		const char *identity, uint8_t *psk, unsigned int max_psk_len);

--- a/tools/mesh-cfgclient.c
+++ b/tools/mesh-cfgclient.c
@@ -707,44 +707,13 @@ static void attach_node_setup(struct l_dbus_message *msg, void *user_data)
 static void create_net_reply(struct l_dbus_proxy *proxy,
 				struct l_dbus_message *msg, void *user_data)
 {
-	char *str;
-	uint64_t tmp;
-
 	if (l_dbus_message_is_error(msg)) {
 		const char *name;
 
 		l_dbus_message_get_error(msg, &name, NULL);
 		l_error("Failed to create network: %s", name);
 		return;
-
 	}
-
-	if (!l_dbus_message_get_arguments(msg, "t", &tmp))
-		return;
-
-	local = l_new(struct meshcfg_node, 1);
-	local->token.u64 = l_get_be64(&tmp);
-	str = l_util_hexstring(&local->token.u8[0], 8);
-	bt_shell_printf("Created new node with token %s\n", str);
-	l_free(str);
-
-	if (!mesh_db_create(cfg_fname, local->token.u8,
-						"Mesh Config Client Network")) {
-		l_free(local);
-		local = NULL;
-		return;
-	}
-
-	mesh_db_set_addr_range(low_addr, high_addr);
-	keys_add_net_key(PRIMARY_NET_IDX);
-	mesh_db_net_key_add(PRIMARY_NET_IDX);
-
-	remote_add_node(app.uuid, 0x0001, 1, PRIMARY_NET_IDX);
-	mesh_db_add_node(app.uuid, 0x0001, 1, PRIMARY_NET_IDX);
-
-	l_dbus_proxy_method_call(net_proxy, "Attach", attach_node_setup,
-						attach_node_reply, NULL,
-						NULL);
 }
 
 static void create_net_setup(struct l_dbus_message *msg, void *user_data)
@@ -1727,7 +1696,7 @@ static struct l_dbus_message *add_node_fail_call(struct l_dbus *dbus,
 static void setup_prov_iface(struct l_dbus_interface *iface)
 {
 	l_dbus_interface_method(iface, "ScanResult", 0, scan_result_call, "",
-						"naya{sv}", "rssi", "data", "options");
+					"naya{sv}", "rssi", "data", "options");
 
 	l_dbus_interface_method(iface, "RequestProvData", 0, req_prov_call,
 				"qq", "y", "net_index", "unicast", "count");
@@ -1779,6 +1748,43 @@ static bool crpl_getter(struct l_dbus *dbus,
 	return true;
 }
 
+static struct l_dbus_message *join_complete(struct l_dbus *dbus,
+						struct l_dbus_message *message,
+						void *user_data)
+{
+	char *str;
+	uint64_t tmp;
+
+	if (!l_dbus_message_get_arguments(message, "t", &tmp))
+		return l_dbus_message_new_error(message, dbus_err_args, NULL);
+
+	local = l_new(struct meshcfg_node, 1);
+	local->token.u64 = l_get_be64(&tmp);
+	str = l_util_hexstring(&local->token.u8[0], 8);
+	bt_shell_printf("Created new node with token %s\n", str);
+	l_free(str);
+
+	if (!mesh_db_create(cfg_fname, local->token.u8,
+					"Mesh Config Client Network")) {
+		l_free(local);
+		local = NULL;
+		return l_dbus_message_new_error(message, dbus_err_fail, NULL);
+	}
+
+	mesh_db_set_addr_range(low_addr, high_addr);
+	keys_add_net_key(PRIMARY_NET_IDX);
+	mesh_db_net_key_add(PRIMARY_NET_IDX);
+
+	remote_add_node(app.uuid, 0x0001, 1, PRIMARY_NET_IDX);
+	mesh_db_add_node(app.uuid, 0x0001, 1, PRIMARY_NET_IDX);
+
+	l_dbus_proxy_method_call(net_proxy, "Attach", attach_node_setup,
+						attach_node_reply, NULL,
+						NULL);
+
+	return l_dbus_message_new_method_return(message);
+}
+
 static void setup_app_iface(struct l_dbus_interface *iface)
 {
 	l_dbus_interface_property(iface, "CompanyID", 0, "q", cid_getter,
@@ -1788,6 +1794,9 @@ static void setup_app_iface(struct l_dbus_interface *iface)
 	l_dbus_interface_property(iface, "ProductID", 0, "q", pid_getter,
 									NULL);
 	l_dbus_interface_property(iface, "CRPL", 0, "q", crpl_getter, NULL);
+
+	l_dbus_interface_method(iface, "JoinComplete", 0, join_complete,
+							"", "t", "token");
 
 	/* TODO: Methods */
 }


### PR DESCRIPTION
This patch changes Import and CreateNetwork API, in current implementation mentioned functions don't return token. Token is passed to application via the JoinComplete method call. When application doesn't raise any error during handling JoinComplete then it is assumed that the token has been saved, otherwise when application replies with an error message then the Node is removed.