### PR TITLE
Node property change signal

### DIFF
--- a/doc/mesh-api.txt
+++ b/doc/mesh-api.txt
@@ -446,6 +446,17 @@ Properties:
 		that the current network is on. This information is only useful
 		for provisioning.
 
+	string IvState [read-only]
+
+		This property may be read at any time to determine the IV
+		Update state that the node is on.
+
+		Possible values:
+			"init"
+			"normal"
+			"updating"
+			"hold"
+
 	uint32 SecondsSinceLastHeard [read-only]
 
 		This property may be read at any time to determine the number of

--- a/mesh/net.c
+++ b/mesh/net.c
@@ -2388,7 +2388,7 @@ static void iv_upd_to(struct l_timeout *upd_timeout, void *user_data)
 		if (net->iv_update)
 			mesh_net_set_seq_num(net, 0);
 
-		net->iv_update = false;
+		mesh_net_set_iv_index(net, net->iv_index, false);
 		mesh_config_write_iv_index(node_config_get(net->node),
 							net->iv_index, false);
 		l_queue_foreach(net->subnets, refresh_beacon, net);
@@ -2407,7 +2407,7 @@ static void iv_upd_to(struct l_timeout *upd_timeout, void *user_data)
 		if (net->iv_update)
 			mesh_net_set_seq_num(net, 0);
 
-		net->iv_update = false;
+		mesh_net_set_iv_index(net, net->iv_index, false);
 
 		if (net->seq_num > IV_UPDATE_SEQ_TRIGGER)
 			mesh_net_iv_index_update(net);
@@ -2563,8 +2563,7 @@ static void update_iv_ivu_state(struct mesh_net *net, uint32_t iv_index,
 		rpl_init(net->node, iv_index);
 	}
 
-	net->iv_index = iv_index;
-	net->iv_update = ivu;
+	mesh_net_set_iv_index(net, iv_index, ivu);
 }
 
 static void process_beacon(void *net_ptr, void *user_data)
@@ -2794,8 +2793,7 @@ bool mesh_net_iv_index_update(struct mesh_net *net)
 		return false;
 
 	net->iv_upd_state = IV_UPD_UPDATING;
-	net->iv_index++;
-	net->iv_update = true;
+	mesh_net_set_iv_index(net, net->iv_index + 1, true);
 	l_queue_foreach(net->subnets, refresh_beacon, net);
 	queue_friend_update(net);
 	net->iv_update_timeout = l_timeout_create(
@@ -3323,6 +3321,8 @@ void mesh_net_set_iv_index(struct mesh_net *net, uint32_t index, bool update)
 {
 	net->iv_index = index;
 	net->iv_update = update;
+
+	node_set_iv_index(net->node, net->iv_index, net->iv_update);
 }
 
 uint16_t mesh_net_get_primary_idx(struct mesh_net *net)

--- a/mesh/net.c
+++ b/mesh/net.c
@@ -68,17 +68,6 @@ enum _relay_advice {
 	RELAY_ALWAYS		/* Relay enabled, msg to a group */
 };
 
-enum _iv_upd_state {
-	/* Allows acceptance of any iv_index secure net beacon */
-	IV_UPD_INIT,
-	/* Normal, can transition, accept current or old */
-	IV_UPD_NORMAL,
-	/* Updating proc running, we use old, accept old or new */
-	IV_UPD_UPDATING,
-	/* Normal, can *not* transition, accept current or old iv_index */
-	IV_UPD_NORMAL_HOLD,
-};
-
 struct net_key {
 	struct mesh_key_set key_set;
 	unsigned int beacon_id;
@@ -112,7 +101,7 @@ struct mesh_net {
 	bool proxy_enable;
 	bool friend_seq;
 	struct l_timeout *iv_update_timeout;
-	enum _iv_upd_state iv_upd_state;
+	enum iv_upd_state iv_upd_state;
 
 	bool iv_update;
 	uint32_t instant; /* Controller Instant of recent Rx */
@@ -890,6 +879,14 @@ uint32_t mesh_net_get_iv_index(struct mesh_net *net)
 		return 0xffffffff;
 
 	return net->iv_index - net->iv_update;
+}
+
+enum iv_upd_state mesh_net_get_iv_upd_state(struct mesh_net *net)
+{
+	if (!net)
+		return IV_UPD_INIT;
+
+	return net->iv_upd_state;
 }
 
 /* TODO: net key index? */

--- a/mesh/net.h
+++ b/mesh/net.h
@@ -253,6 +253,17 @@ struct mesh_friend_msg {
 	} u;
 };
 
+enum iv_upd_state {
+	/* Allows acceptance of any iv_index secure net beacon */
+	IV_UPD_INIT,
+	/* Normal, can transition, accept current or old */
+	IV_UPD_NORMAL,
+	/* Updating proc running, we use old, accept old or new */
+	IV_UPD_UPDATING,
+	/* Normal, can *not* transition, accept current or old iv_index */
+	IV_UPD_NORMAL_HOLD,
+};
+
 typedef void (*mesh_status_func_t)(void *user_data, bool result);
 
 struct mesh_net *mesh_net_new(struct mesh_node *node);
@@ -284,6 +295,7 @@ int mesh_net_update_key(struct mesh_net *net, uint16_t net_idx,
 bool mesh_net_set_key(struct mesh_net *net, uint16_t idx, const uint8_t *key,
 					const uint8_t *new_key, uint8_t phase);
 uint32_t mesh_net_get_iv_index(struct mesh_net *net);
+enum iv_upd_state mesh_net_get_iv_upd_state(struct mesh_net *net);
 void mesh_net_get_snb_state(struct mesh_net *net,
 					uint8_t *flags, uint32_t *iv_index);
 bool mesh_net_get_key(struct mesh_net *net, bool new_key, uint16_t idx,

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -701,6 +701,24 @@ bool node_default_ttl_set(struct mesh_node *node, uint8_t ttl)
 	return res;
 }
 
+void node_set_iv_index(struct mesh_node *node, uint32_t iv_index,
+								bool iv_update)
+{
+	struct l_dbus *bus = dbus_get_bus();
+
+	if (node->obj_path)
+	{
+		l_dbus_property_changed(bus, node->obj_path,
+						MESH_NODE_INTERFACE, "IvIndex");
+
+		l_dbus_property_changed(bus, node->obj_path,
+					MESH_NODE_INTERFACE, "IvUpdate");
+
+		l_dbus_property_changed(bus, node->obj_path,
+					MESH_NODE_INTERFACE, "IvState");
+	}
+}
+
 bool node_set_sequence_number(struct mesh_node *node, uint32_t seq)
 {
 	if (!node)

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -2233,6 +2233,37 @@ static bool ivindex_getter(struct l_dbus *dbus, struct l_dbus_message *msg,
 	return true;
 }
 
+static bool ivstate_getter(struct l_dbus *dbus, struct l_dbus_message *msg,
+					struct l_dbus_message_builder *builder,
+					void *user_data)
+{
+	struct mesh_node *node = user_data;
+	struct mesh_net *net = node_get_net(node);
+	const char *ivupdate = "";
+
+	switch (mesh_net_get_iv_upd_state(net)) {
+	case IV_UPD_INIT:
+		ivupdate = "init";
+		break;
+
+	case IV_UPD_NORMAL:
+		ivupdate = "normal";
+		break;
+
+	case IV_UPD_UPDATING:
+		ivupdate = "updating";
+		break;
+
+	case IV_UPD_NORMAL_HOLD:
+		ivupdate = "hold";
+		break;
+	}
+
+	l_dbus_message_builder_append_basic(builder, 's', ivupdate);
+
+	return true;
+}
+
 static bool seq_num_getter(struct l_dbus *dbus, struct l_dbus_message *msg,
 				struct l_dbus_message_builder *builder,
 				void *user_data)
@@ -2317,6 +2348,8 @@ static void setup_node_interface(struct l_dbus_interface *iface)
 									NULL);
 	l_dbus_interface_property(iface, "IvIndex", 0, "u", ivindex_getter,
 									NULL);
+	l_dbus_interface_property(iface, "IvState", 0, "s",
+							ivstate_getter, NULL);
 	l_dbus_interface_property(iface, "SequenceNumber", 0, "u",
 							seq_num_getter, NULL);
 	l_dbus_interface_property(iface, "SecondsSinceLastHeard", 0, "u",

--- a/mesh/node.h
+++ b/mesh/node.h
@@ -55,6 +55,8 @@ bool node_del_binding(struct mesh_node *node, uint8_t ele_idx,
 			uint32_t model_id, uint16_t app_idx);
 uint8_t node_default_ttl_get(struct mesh_node *node);
 bool node_default_ttl_set(struct mesh_node *node, uint8_t ttl);
+void node_set_iv_index(struct mesh_node *node, uint32_t iv_index,
+								bool iv_update);
 bool node_set_sequence_number(struct mesh_node *node, uint32_t seq);
 uint32_t node_get_sequence_number(struct mesh_node *node);
 int node_get_element_idx(struct mesh_node *node, uint16_t ele_addr);


### PR DESCRIPTION
This PR makes it a bit easier to write tests for IV Index scenarios - instead of waiting for logs, we can now wait for property changes.