### PR TITLE
amqp: Subscribe to all raw remote control messages within the exchange

### DIFF
--- a/mesh/amqp.c
+++ b/mesh/amqp.c
@@ -470,7 +470,7 @@ static bool amqp_consume(struct amqp_thread_context *context)
 	amqp_queue_bind(context->conn_state, 1, /* channel */
 			amqp_cstring_bytes(name), /* queue name */
 			amqp_cstring_bytes(context->config.exchange), /* exchange */
-			amqp_cstring_bytes(name), /* routing_key */
+			amqp_cstring_bytes("rc.#.raw"), /* routing_key */
 			amqp_empty_table); /* args */
 
 	reply = amqp_get_rpc_reply(context->conn_state);


### PR DESCRIPTION
This allows the remote side to publish a single rc message to relevant exchange, instead of iterating over list of gateways in the project to publish multiple messages with different routing keys.

All gateways will receive this publication, but some might drop it because of missing application key.