### PR TITLE
[WIP] mesh: Add 'gateway-uuid' header to published AMQP messages

### DIFF
--- a/mesh/amqp.h
+++ b/mesh/amqp.h
@@ -31,6 +31,7 @@ enum mesh_amqp_state {
 };
 
 struct mesh_amqp_config {
+	char *uuid;
 	char *url;
 	char *exchange;
 	char *routing_key;
@@ -64,7 +65,7 @@ void mesh_amqp_subscribe(struct mesh_amqp *amqp, const char *topic,
 void mesh_amqp_unsubscribe(struct mesh_amqp *amqp, const char *topic,
 			mesh_amqp_complete_cb_t complete, void *user_data);
 
-void mesh_amqp_start(struct mesh_amqp *amqp);
+void mesh_amqp_start(struct mesh_amqp *amqp, const uint8_t uuid[16]);
 void mesh_amqp_stop(struct mesh_amqp *amqp);
 
 bool mesh_amqp_is_ready(struct mesh_amqp *amqp);

--- a/mesh/node.c
+++ b/mesh/node.c
@@ -497,7 +497,7 @@ static bool init_from_storage(struct mesh_config_node *db_node,
 	node->relay.interval = db_node->modes.relay.interval;
 	node->beacon = db_node->modes.beacon;
 
-	mesh_amqp_start(node->amqp);
+	mesh_amqp_start(node->amqp, node->uuid);
 
 	l_debug("relay %2.2x, proxy %2.2x, lpn %2.2x, friend %2.2x",
 			node->relay.mode, node->proxy, node->lpn, node->friend);
@@ -2886,5 +2886,5 @@ void node_finalize_new_node(struct mesh_node *node, struct mesh_io *io)
 
 	/* Register callback for the node's io */
 	attach_io(node, io);
-	mesh_amqp_start(node->amqp);
+	mesh_amqp_start(node->amqp, node->uuid);
 }


### PR DESCRIPTION
For debugging and monitoring, it is useful to know which bluez node
relayed the message to the broker. This patch adds a 'gateway-uuid'
header to each message, with gateway's uuid encoded in hex.